### PR TITLE
fix: typos in documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ For example, a new change to the PARSER crate might have the following message: 
     // ================================================================================
     ```
 
-- [Rustfmt](https://github.com/rust-lang/rustfmt) and [Clippy](https://github.com/rust-lang/rust-clippy) linting is included in CI pipeline. Anyways it's prefferable to run linting locally before push:
+- [Rustfmt](https://github.com/rust-lang/rustfmt) and [Clippy](https://github.com/rust-lang/rust-clippy) linting is included in CI pipeline. Anyways it's preferable to run linting locally before push:
     ```
     cargo fix --allow-staged --allow-dirty --all-targets --all-features; cargo fmt; cargo clippy --workspace --all-targets --all-features -- -D warnings
     ```

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1333,7 +1333,7 @@ impl<'a> SemanticAnalysis<'a> {
                                 }
                             }
                             // We take care to only allow constructing Call with a function identifier, but it
-                            // is possible for someone to unintentionally set the callee to a binding identifer, which is
+                            // is possible for someone to unintentionally set the callee to a binding identifier, which is
                             // a compiler internal error, hence the panic
                             id => panic!("invalid callee identifier, expected function id, got binding: {:#?}", id),
                         }

--- a/parser/src/transforms/inlining.rs
+++ b/parser/src/transforms/inlining.rs
@@ -704,7 +704,7 @@ impl<'a> Inlining<'a> {
                     }
                     // If the current statement is a `let`-tree, we need to generate a new `let` at
                     // the bottom of the tree, which binds the result expression as the value of the
-                    // generated `let`, and uses the accumualtor expression as the body
+                    // generated `let`, and uses the accumulator expression as the body
                     Statement::Let(ref mut wrapper) => {
                         with_let_result(self, &mut wrapper.body, move |_, value| {
                             let value = core::mem::replace(


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.