### PR TITLE
feat: Allow unconstrained boundaries for buses

### DIFF
--- a/air-script/tests/buses/buses_simple.air
+++ b/air-script/tests/buses/buses_simple.air
@@ -14,6 +14,7 @@ public_inputs {
 }
 
 boundary_constraints {
+    enf p.first = unconstrained;
     enf q.first = null;
     enf p.last = null;
     enf q.last = null;

--- a/air-script/tests/buses/buses_simple.air
+++ b/air-script/tests/buses/buses_simple.air
@@ -14,7 +14,6 @@ public_inputs {
 }
 
 boundary_constraints {
-    enf p.first = null;
     enf q.first = null;
     enf p.last = null;
     enf q.last = null;

--- a/air-script/tests/buses/buses_simple.rs
+++ b/air-script/tests/buses/buses_simple.rs
@@ -50,7 +50,7 @@ impl Air for BusesAir {
         let main_degrees = vec![];
         let aux_degrees = vec![TransitionConstraintDegree::new(2), TransitionConstraintDegree::new(1)];
         let num_main_assertions = 0;
-        let num_aux_assertions = 4;
+        let num_aux_assertions = 3;
 
         let context = AirContext::new_multi_segment(
             trace_info,
@@ -75,7 +75,6 @@ impl Air for BusesAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
         let mut result = Vec::new();
-        result.push(Assertion::single(0, 0, E::ONE));
         result.push(Assertion::single(0, self.last_step(), E::ONE));
         result.push(Assertion::single(1, 0, E::ZERO));
         result.push(Assertion::single(1, self.last_step(), E::ZERO));

--- a/air/src/ir/bus.rs
+++ b/air/src/ir/bus.rs
@@ -26,6 +26,8 @@ pub enum BusBoundary {
     PublicInputTable(PublicInputTableAccess),
     /// A reference to an empty bus
     Null,
+    /// An unconstrained bus boundary
+    Unconstrained,
 }
 
 /// Represents an access of a public input table, similar in nature to [TraceAccess].

--- a/air/src/passes/expand_buses.rs
+++ b/air/src/passes/expand_buses.rs
@@ -112,6 +112,8 @@ impl<'a> BusOpExpand<'a> {
             // Boundaries to PublicInputTable should be handled later during codegen, as we cannot
             // know at this point the length of the table, so we cannot generate the resulting constraint
             BusBoundary::PublicInputTable(_public_input_table_access) => {}
+            // Unconstrained boundaries do not require any constraints
+            BusBoundary::Unconstrained => {}
             BusBoundary::Null => {
                 // The value of the constraint for an empty bus depends on the bus types (1 for multiset, 0 for logup)
                 let value = match bus_type {

--- a/air/src/passes/translate_from_ast.rs
+++ b/air/src/passes/translate_from_ast.rs
@@ -428,7 +428,7 @@ impl AirBuilder<'_> {
             ast::Expr::Let(ref let_expr) => self.eval_let_expr(let_expr),
             // These node types should not exist at this point
             ast::Expr::Call(_) | ast::Expr::ListComprehension(_) => unreachable!(),
-            ast::Expr::BusOperation(_) | ast::Expr::Null(_) => {
+            ast::Expr::BusOperation(_) | ast::Expr::Null(_) | ast::Expr::Unconstrained(_) => {
                 self.diagnostics
                     .diagnostic(Severity::Error)
                     .with_message("buses are not implemented for this Pipeline")
@@ -454,7 +454,8 @@ impl AirBuilder<'_> {
             ast::ScalarExpr::Call(_)
             | ast::ScalarExpr::BoundedSymbolAccess(_)
             | ast::ScalarExpr::BusOperation(_)
-            | ast::ScalarExpr::Null(_) => unreachable!(),
+            | ast::ScalarExpr::Null(_)
+            | ast::ScalarExpr::Unconstrained(_) => unreachable!(),
         }
     }
 

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -608,6 +608,10 @@ fn build_bus_boundary(mir_bus_boundary_node: &Link<Op>) -> Result<BusBoundary, C
             MirValue::Null => Ok(crate::ir::BusBoundary::Null),
             _ => Err(CompileError::Failed),
         },
+        Op::None(_) => {
+            // This is an unconstrained bus boundary
+            Ok(crate::ir::BusBoundary::Unconstrained)
+        }
         _ => unreachable!("Unexpected Mir Op in bus boundary: {:#?}", mir_node_ref),
     }
 }

--- a/air/src/tests/buses.rs
+++ b/air/src/tests/buses.rs
@@ -60,7 +60,7 @@ fn buses_in_integrity_constraints() {
     }
 
     boundary_constraints {
-        enf p.first = null;
+        enf p.first = unconstrained;
         enf q.first = null;
         enf p.last = inputs;
         enf q.last = inputs;
@@ -142,4 +142,40 @@ fn err_trace_columns_constrained_with_null() {
 
     expect_diagnostic(source, "error: invalid constraint", Pipeline::WithoutMIR);
     expect_diagnostic(source, "error: invalid constraint", Pipeline::WithMIR);
+}
+
+#[test]
+fn err_buses_unconstrained() {
+    let source = "
+        def test
+
+    trace_columns {
+        main: [a],
+    }
+
+    buses {
+        multiset p,
+        logup q,
+    }
+
+    public_inputs {
+        inputs: [2],
+    }
+
+    boundary_constraints {
+        enf p.first = null;
+        enf p.last = null;
+        enf q.first = null;
+    }
+
+    integrity_constraints {
+        enf a = 0;
+    }";
+
+    expect_diagnostic(
+        source,
+        "error: buses are not implemented for this Pipeline",
+        Pipeline::WithoutMIR,
+    );
+    expect_diagnostic(source, "error: invalid bus boundary", Pipeline::WithMIR);
 }

--- a/air/src/tests/variables.rs
+++ b/air/src/tests/variables.rs
@@ -198,8 +198,8 @@ fn invalid_matrix_literal_with_leading_vector_binding() {
         enf clk' = d[0][0];
     }";
 
-    expect_diagnostic(source, "expected one of: '\"!\"', '\"(\"', '\"null\"', 'decl_ident_ref', 'function_identifier', 'identifier', 'int'", Pipeline::WithoutMIR);
-    expect_diagnostic(source, "expected one of: '\"!\"', '\"(\"', '\"null\"', 'decl_ident_ref', 'function_identifier', 'identifier', 'int'", Pipeline::WithMIR);
+    expect_diagnostic(source, "expected one of: '\"!\"', '\"(\"', '\"null\"', '\"unconstrained\"', 'decl_ident_ref', 'function_identifier', 'identifier', 'int'", Pipeline::WithoutMIR);
+    expect_diagnostic(source, "expected one of: '\"!\"', '\"(\"', '\"null\"', '\"unconstrained\"', 'decl_ident_ref', 'function_identifier', 'identifier', 'int'", Pipeline::WithMIR);
 }
 
 #[test]

--- a/codegen/winterfell/src/air/boundary_constraints.rs
+++ b/codegen/winterfell/src/air/boundary_constraints.rs
@@ -128,7 +128,7 @@ fn add_aux_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
 
                     func_body.line(assertion);
                 }
-                air_ir::BusBoundary::Null => {}
+                air_ir::BusBoundary::Null | air_ir::BusBoundary::Unconstrained => {}
             }
         }
     }

--- a/mir/src/ir/nodes/ops/value.rs
+++ b/mir/src/ir/nodes/ops/value.rs
@@ -75,7 +75,10 @@ pub enum MirValue {
     TraceAccessBinding(TraceAccessBinding),
     /// A binding to a [Bus].
     BusAccess(BusAccess),
+    /// An empty bus
     Null,
+    /// An unconstrained bus
+    Unconstrained,
 }
 
 /// [BusAccess] is like [SymbolAccess], but is used to describe an access to a specific bus.

--- a/mir/src/ir/utils.rs
+++ b/mir/src/ir/utils.rs
@@ -255,7 +255,7 @@ impl Visitor for StripSpansVisitor {
             MirValue::RandomValue(_) => {}
             MirValue::TraceAccessBinding(_) => {}
             MirValue::BusAccess(_) => {}
-            MirValue::Null => {}
+            MirValue::Null | MirValue::Unconstrained => {}
         }
         Ok(())
     }

--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -420,6 +420,10 @@ impl<'a> MirBuilder<'a> {
                 span: expr.span(),
                 value: MirValue::Null,
             })),
+            ast::Expr::Unconstrained(_) => Ok(Value::create(SpannedMirValue {
+                span: expr.span(),
+                value: MirValue::Unconstrained,
+            })),
             ast::Expr::BusOperation(bo) => self.translate_bus_operation(bo),
         }
     }
@@ -1016,6 +1020,10 @@ impl<'a> MirBuilder<'a> {
             ast::ScalarExpr::Null(_) => Ok(Value::create(SpannedMirValue {
                 span: scalar_expr.span(),
                 value: MirValue::Null,
+            })),
+            ast::ScalarExpr::Unconstrained(_) => Ok(Value::create(SpannedMirValue {
+                span: scalar_expr.span(),
+                value: MirValue::Unconstrained,
             })),
             ast::ScalarExpr::BusOperation(bo) => self.translate_bus_operation(bo),
         }

--- a/mir/src/passes/unrolling.rs
+++ b/mir/src/passes/unrolling.rs
@@ -204,6 +204,7 @@ impl UnrollingFirstPass<'_> {
                 }
                 MirValue::BusAccess(_) => {}
                 MirValue::Null => {}
+                MirValue::Unconstrained => {}
             }
         }
 

--- a/mir/src/tests/variables.rs
+++ b/mir/src/tests/variables.rs
@@ -183,7 +183,7 @@ fn invalid_matrix_literal_with_leading_vector_binding() {
         enf clk' = d[0][0];
     }";
 
-    expect_diagnostic(source, "expected one of: '\"!\"', '\"(\"', '\"null\"', 'decl_ident_ref', 'function_identifier', 'identifier', 'int'");
+    expect_diagnostic(source, "expected one of: '\"!\"', '\"(\"', '\"null\"', '\"unconstrained\"', 'decl_ident_ref', 'function_identifier', 'identifier', 'int'");
 }
 
 #[test]

--- a/parser/src/ast/expression.rs
+++ b/parser/src/ast/expression.rs
@@ -306,6 +306,8 @@ pub enum Expr {
     BusOperation(BusOperation),
     /// An empty bus
     Null(Span<()>),
+    /// An unconstrained bus
+    Unconstrained(Span<()>),
 }
 impl Expr {
     /// Returns true if this expression is constant
@@ -340,7 +342,7 @@ impl Expr {
             Self::Call(ref call) => call.ty,
             Self::ListComprehension(ref lc) => lc.ty,
             Self::Let(ref let_expr) => let_expr.ty(),
-            Self::BusOperation(_) | Self::Null(_) => Some(Type::Felt),
+            Self::BusOperation(_) | Self::Null(_) | Self::Unconstrained(_) => Some(Type::Felt),
         }
     }
 }
@@ -360,6 +362,7 @@ impl fmt::Debug for Expr {
             Self::Let(ref let_expr) => write!(f, "{let_expr:#?}"),
             Self::BusOperation(ref expr) => f.debug_tuple("BusOp").field(expr).finish(),
             Self::Null(ref expr) => f.debug_tuple("Null").field(expr).finish(),
+            Self::Unconstrained(ref expr) => f.debug_tuple("Unconstrained").field(expr).finish(),
         }
     }
 }
@@ -393,6 +396,7 @@ impl fmt::Display for Expr {
             }
             Self::BusOperation(ref expr) => write!(f, "{}", expr),
             Self::Null(ref _expr) => write!(f, "null"),
+            Self::Unconstrained(ref _expr) => write!(f, "unconstrained"),
         }
     }
 }
@@ -456,6 +460,7 @@ impl TryFrom<ScalarExpr> for Expr {
             ScalarExpr::Let(expr) => Ok(Self::Let(expr)),
             ScalarExpr::BusOperation(expr) => Ok(Self::BusOperation(expr)),
             ScalarExpr::Null(spanned) => Ok(Self::Null(spanned)),
+            ScalarExpr::Unconstrained(spanned) => Ok(Self::Unconstrained(spanned)),
         }
     }
 }
@@ -508,6 +513,8 @@ pub enum ScalarExpr {
     BusOperation(BusOperation),
     /// An empty bus
     Null(Span<()>),
+    /// An unconstrained bus
+    Unconstrained(Span<()>),
 }
 impl ScalarExpr {
     /// Returns true if this is a constant value
@@ -542,7 +549,9 @@ impl ScalarExpr {
             },
             Self::Call(ref expr) => Ok(expr.ty),
             Self::Let(ref expr) => Ok(expr.ty()),
-            Self::BusOperation(_) | ScalarExpr::Null(_) => Ok(Some(Type::Felt)),
+            Self::BusOperation(_) | ScalarExpr::Null(_) | ScalarExpr::Unconstrained(_) => {
+                Ok(Some(Type::Felt))
+            }
         }
     }
 }
@@ -601,6 +610,7 @@ impl fmt::Debug for ScalarExpr {
             Self::Let(ref expr) => write!(f, "{:#?}", expr),
             Self::BusOperation(ref expr) => f.debug_tuple("BusOp").field(expr).finish(),
             Self::Null(ref expr) => f.debug_tuple("Null").field(expr).finish(),
+            Self::Unconstrained(ref expr) => f.debug_tuple("Unconstrained").field(expr).finish(),
         }
     }
 }
@@ -622,6 +632,7 @@ impl fmt::Display for ScalarExpr {
             }
             Self::BusOperation(ref expr) => write!(f, "{}", expr),
             Self::Null(ref _value) => write!(f, "null"),
+            Self::Unconstrained(ref _value) => write!(f, "unconstrained"),
         }
     }
 }

--- a/parser/src/ast/visit.rs
+++ b/parser/src/ast/visit.rs
@@ -623,7 +623,7 @@ where
         ast::Expr::ListComprehension(ref mut expr) => visitor.visit_mut_list_comprehension(expr),
         ast::Expr::Let(ref mut expr) => visitor.visit_mut_let(expr),
         ast::Expr::BusOperation(ref mut expr) => visitor.visit_mut_bus_operation(expr),
-        ast::Expr::Null(_) => ControlFlow::Continue(()),
+        ast::Expr::Null(_) | ast::Expr::Unconstrained(_) => ControlFlow::Continue(()),
     }
 }
 
@@ -632,7 +632,9 @@ where
     V: ?Sized + VisitMut<T>,
 {
     match expr {
-        ast::ScalarExpr::Const(_) | ast::ScalarExpr::Null(_) => ControlFlow::Continue(()),
+        ast::ScalarExpr::Const(_)
+        | ast::ScalarExpr::Null(_)
+        | ast::ScalarExpr::Unconstrained(_) => ControlFlow::Continue(()),
         ast::ScalarExpr::SymbolAccess(ref mut expr) => visitor.visit_mut_symbol_access(expr),
         ast::ScalarExpr::BoundedSymbolAccess(ref mut expr) => {
             visitor.visit_mut_bounded_symbol_access(expr)

--- a/parser/src/lexer/mod.rs
+++ b/parser/src/lexer/mod.rs
@@ -121,6 +121,8 @@ pub enum Token {
     Logup,
     /// Used to represent an empty bus
     Null,
+    /// Used to represent an unconstrained bus
+    Unconstrained,
     /// Used to represent the insertion of a given tuple into a bus
     Insert,
     /// Used to represent the removal of a given tuple from a bus
@@ -200,6 +202,7 @@ impl Token {
             "multiset" => Self::Multiset,
             "logup" => Self::Logup,
             "null" => Self::Null,
+            "unconstrained" => Self::Unconstrained,
             "insert" => Self::Insert,
             "remove" => Self::Remove,
             "boundary_constraints" => Self::BoundaryConstraints,
@@ -278,6 +281,7 @@ impl fmt::Display for Token {
             Self::Multiset => write!(f, "multiset"),
             Self::Logup => write!(f, "logup"),
             Self::Null => write!(f, "null"),
+            Self::Unconstrained => write!(f, "unconstrained"),
             Self::Insert => write!(f, "insert"),
             Self::Remove => write!(f, "remove"),
             Self::BoundaryConstraints => write!(f, "boundary_constraints"),

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -464,6 +464,7 @@ ScalarExprBase: ScalarExpr = {
     SymbolAccess,
     <Int> => ScalarExpr::Const(<>),
     <l:@L> "null" <r:@R> => ScalarExpr::Null(Span::new(span!(l, r), ())),
+    <l:@L> "unconstrained" <r:@R> => ScalarExpr::Unconstrained(Span::new(span!(l, r), ())),
     "(" <ScalarExpr> ")",
 
     #[precedence(level="1")]
@@ -665,6 +666,7 @@ extern {
         "multiset" => Token::Multiset,
         "logup" => Token::Logup,
         "null" => Token::Null,
+        "unconstrained" => Token::Unconstrained,
         "insert" => Token::Insert,
         "remove" => Token::Remove,
         "boundary_constraints" => Token::BoundaryConstraints,

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1390,7 +1390,7 @@ impl SemanticAnalysis<'_> {
                             };
 
                         match (found.clone().item, expr.rhs.as_mut()) {
-                            // Buses boundaries can be constrained by null or unconstrained
+                            // Buses boundaries can be constrained by null or set to be unconstrained
                             (
                                 BindingType::Bus(_),
                                 ScalarExpr::Null(_) | ScalarExpr::Unconstrained(_),
@@ -1440,7 +1440,7 @@ impl SemanticAnalysis<'_> {
                                     .emit();
                             }
                             (_, ScalarExpr::Null(_) | ScalarExpr::Unconstrained(_)) => {
-                                // Only buses can be constrained to null or unconstrained
+                                // Only buses can be constrained to null or set to be unconstrained
                                 self.has_type_errors = true;
                                 self.invalid_constraint(
                                     expr.lhs.span(),
@@ -1448,9 +1448,9 @@ impl SemanticAnalysis<'_> {
                                 )
                                 .with_secondary_label(
                                     expr.rhs.span(),
-                                    "but this expression is only valid to for bus boundaries",
+                                    "but this expression is only valid for constraining buses",
                                 )
-                                .with_note("The null / unconstrained value is only valid for defining empty buses")
+                                .with_note("The null / unconstrained keywords are only valid for constraining buses, not columns")
                                 .emit();
                             }
                             _ => {

--- a/parser/src/transforms/constant_propagation.rs
+++ b/parser/src/transforms/constant_propagation.rs
@@ -186,7 +186,9 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
     ) -> ControlFlow<SemanticAnalysisError> {
         match expr {
             // Expression is already folded
-            ScalarExpr::Const(_) | ScalarExpr::Null(_) => ControlFlow::Continue(()),
+            ScalarExpr::Const(_) | ScalarExpr::Null(_) | ScalarExpr::Unconstrained(_) => {
+                ControlFlow::Continue(())
+            }
             // Need to check if this access is to a constant value, and transform to a constant if so
             ScalarExpr::SymbolAccess(sym) => {
                 let constant_value = match sym.name {
@@ -644,7 +646,7 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                 ControlFlow::Continue(())
             }
             Expr::BusOperation(ref mut expr) => self.visit_mut_bus_operation(expr),
-            Expr::Null(_) => ControlFlow::Continue(()),
+            Expr::Null(_) | Expr::Unconstrained(_) => ControlFlow::Continue(()),
         }
     }
 

--- a/parser/src/transforms/inlining.rs
+++ b/parser/src/transforms/inlining.rs
@@ -343,7 +343,7 @@ impl<'a> Inlining<'a> {
                 Expr::try_from(block.pop().unwrap()).map_err(SemanticAnalysisError::InvalidExpr)
             }
             expr @ (Expr::Const(_) | Expr::Range(_) | Expr::SymbolAccess(_)) => Ok(expr),
-            Expr::BusOperation(_) | Expr::Null(_) => {
+            Expr::BusOperation(_) | Expr::Null(_) | Expr::Unconstrained(_) => {
                 self.diagnostics
                     .diagnostic(Severity::Error)
                     .with_message("buses are not implemented for this Pipeline")
@@ -667,7 +667,7 @@ impl<'a> Inlining<'a> {
                     }
                 }
             }
-            Expr::BusOperation(_) | Expr::Null(_) => {
+            Expr::BusOperation(_) | Expr::Null(_) | Expr::Unconstrained(_) => {
                 self.diagnostics
                     .diagnostic(Severity::Error)
                     .with_message("buses are not implemented for this Pipeline")
@@ -732,7 +732,7 @@ impl<'a> Inlining<'a> {
                 }
                 Ok(())
             }
-            ScalarExpr::BusOperation(_) | ScalarExpr::Null(_) => {
+            ScalarExpr::BusOperation(_) | ScalarExpr::Null(_) | ScalarExpr::Unconstrained(_) => {
                 self.diagnostics
                     .diagnostic(Severity::Error)
                     .with_message("buses are not implemented for this Pipeline")
@@ -1014,7 +1014,8 @@ impl<'a> Inlining<'a> {
                 | Expr::ListComprehension(_)
                 | Expr::Let(_)
                 | Expr::BusOperation(_)
-                | Expr::Null(_) => {
+                | Expr::Null(_)
+                | Expr::Unconstrained(_) => {
                     unreachable!()
                 }
             };
@@ -1600,7 +1601,7 @@ fn eval_expr_binding_type(
             eval_expr_binding_type(&lc.iterables[0], bindings, imported)
         }
         Expr::Let(ref let_expr) => eval_let_binding_ty(let_expr, bindings, imported),
-        Expr::BusOperation(_) | Expr::Null(_) => {
+        Expr::BusOperation(_) | Expr::Null(_) | Expr::Unconstrained(_) => {
             unimplemented!("buses are not implemented for this Pipeline")
         }
     }
@@ -1743,7 +1744,8 @@ impl RewriteIterableBindingsVisitor<'_> {
                 | Expr::ListComprehension(_)
                 | Expr::Let(_)
                 | Expr::BusOperation(_)
-                | Expr::Null(_),
+                | Expr::Null(_)
+                | Expr::Unconstrained(_),
             ) => {
                 unreachable!()
             }
@@ -1802,7 +1804,7 @@ impl VisitMut<SemanticAnalysisError> for RewriteIterableBindingsVisitor<'_> {
             // the case that we encounter a let here, as they can only be introduced in scalar
             // expression position as a result of inlining/expansion
             ScalarExpr::Let(_) => unreachable!(),
-            ScalarExpr::BusOperation(_) | ScalarExpr::Null(_) => {
+            ScalarExpr::BusOperation(_) | ScalarExpr::Null(_) | ScalarExpr::Unconstrained(_) => {
                 ControlFlow::Break(SemanticAnalysisError::Invalid)
             }
         }


### PR DESCRIPTION
As currently boundary constraints can only be in the form `b.boundary = null | input`, it is not currently possible to represent some constraints needed for MidenVM, so we may want to allow unconstraint boudaries for now:

 _Originally posted by @Al-Kindi-0 in [#377](https://github.com/0xMiden/air-script/issues/377#issuecomment-2886593538):_

> Note that before the changes in #375 , we could have un-constrained columns in the auxiliary trace which allowed us to not be blocked by the need for having a fix for #396 and hence be able to generate the ACE circuit for the reduced set of Miden VM constraints.
> As far as I can see this is no longer possible i.e., once we define a bus we have to constrain it and without #375 we cannot define the correct constraints on the last row of both the chiplets virtual table and chiplet bus. With the wrong constraints, the ACE circuit will not evaluate to zero.

We introduce the `unconstrained` keyword to explicitely allow a certain bus boundary to be unconstrained. If we simply forget to put a constraint for a bus, we raise a diagnostic.