### PR TITLE
refactor(bus boundaries): Add `PublicInputTable` node type to IR to handle bus boundary constraints uniformly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Introduced initial version of the ACE backend (#370, #380, #386).
 - Updated Winterfell codegen to the latest version (#388).
 - Removed obsolete MASM codegen backend (#389).
+- Add node to graph referencing reduced public input tables ([#414](https://github.com/0xMiden/air-script/issues/414))
 
 ### Internal
 

--- a/air-script/tests/buses/buses_varlen_boundary_both.air
+++ b/air-script/tests/buses/buses_varlen_boundary_both.air
@@ -16,8 +16,8 @@ public_inputs {
 
 boundary_constraints {
     enf p.first = inputs;
-    enf q.first = inputs;
-    enf p.last = outputs;
+    enf q.first = null;
+    enf p.last = unconstrained;
     enf q.last = outputs;
 }
 

--- a/air-script/tests/buses/buses_varlen_boundary_both.rs
+++ b/air-script/tests/buses/buses_varlen_boundary_both.rs
@@ -81,7 +81,7 @@ impl Air for BusesAir {
         let main_degrees = vec![];
         let aux_degrees = vec![TransitionConstraintDegree::new(2), TransitionConstraintDegree::new(1)];
         let num_main_assertions = 0;
-        let num_aux_assertions = 4;
+        let num_aux_assertions = 3;
 
         let context = AirContext::new_multi_segment(
             trace_info,
@@ -106,10 +106,11 @@ impl Air for BusesAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
         let mut result = Vec::new();
-        result.push(Assertion::single(0, 0, Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs.iter())));
-        result.push(Assertion::single(1, 0, Self::bus_logup_boundary_varlen(aux_rand_elements, &self.inputs.iter())));
-        result.push(Assertion::single(0, self.last_step(), Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.outputs.iter())));
-        result.push(Assertion::single(1, self.last_step(), Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs.iter())));
+        let reduced_inputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs.iter());
+        let reduced_outputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs.iter());
+        result.push(Assertion::single(0, 0, reduced_inputs_multiset));
+        result.push(Assertion::single(1, 0, E::ZERO));
+        result.push(Assertion::single(1, self.last_step(), reduced_outputs_logup));
         result
     }
 

--- a/air-script/tests/buses/buses_varlen_boundary_both.rs
+++ b/air-script/tests/buses/buses_varlen_boundary_both.rs
@@ -41,10 +41,10 @@ impl BusesAir {
         self.trace_length() - self.context().num_transition_exemptions()
     }
 
-    pub fn bus_multiset_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]> + Clone, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: &I) -> E {
+    pub fn bus_multiset_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]>, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: I) -> E {
         let mut bus_p_last: E = E::ONE;
         let rand = aux_rand_elements.rand_elements();
-        for row in public_inputs.clone().into_iter() {
+        for row in public_inputs {
             let mut p_last = rand[0];
             for (c, p_i) in row.iter().enumerate() {
                 p_last += E::from(*p_i) * rand[c + 1];
@@ -54,10 +54,10 @@ impl BusesAir {
         bus_p_last
     }
 
-    pub fn bus_logup_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]> + Clone, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: &I) -> E {
+    pub fn bus_logup_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]>, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: I) -> E {
         let mut bus_q_last = E::ZERO;
         let rand = aux_rand_elements.rand_elements();
-        for row in public_inputs.clone().into_iter() {
+        for row in public_inputs {
             let mut q_last = rand[0];
             for (c, p_i) in row.iter().enumerate() {
                 let p_i = *p_i;
@@ -106,8 +106,8 @@ impl Air for BusesAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
         let mut result = Vec::new();
-        let reduced_inputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs.iter());
-        let reduced_outputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs.iter());
+        let reduced_inputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs);
+        let reduced_outputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs);
         result.push(Assertion::single(0, 0, reduced_inputs_multiset));
         result.push(Assertion::single(1, 0, E::ZERO));
         result.push(Assertion::single(1, self.last_step(), reduced_outputs_logup));

--- a/air-script/tests/buses/buses_varlen_boundary_first.rs
+++ b/air-script/tests/buses/buses_varlen_boundary_first.rs
@@ -102,10 +102,12 @@ impl Air for BusesAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
         let mut result = Vec::new();
+        let reduced_inputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs.iter());
+        let reduced_inputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.inputs.iter());
+        result.push(Assertion::single(0, 0, reduced_inputs_multiset));
         result.push(Assertion::single(0, self.last_step(), E::ONE));
+        result.push(Assertion::single(1, 0, reduced_inputs_logup));
         result.push(Assertion::single(1, self.last_step(), E::ZERO));
-        result.push(Assertion::single(0, 0, Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs.iter())));
-        result.push(Assertion::single(1, 0, Self::bus_logup_boundary_varlen(aux_rand_elements, &self.inputs.iter())));
         result
     }
 

--- a/air-script/tests/buses/buses_varlen_boundary_first.rs
+++ b/air-script/tests/buses/buses_varlen_boundary_first.rs
@@ -37,10 +37,10 @@ impl BusesAir {
         self.trace_length() - self.context().num_transition_exemptions()
     }
 
-    pub fn bus_multiset_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]> + Clone, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: &I) -> E {
+    pub fn bus_multiset_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]>, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: I) -> E {
         let mut bus_p_last: E = E::ONE;
         let rand = aux_rand_elements.rand_elements();
-        for row in public_inputs.clone().into_iter() {
+        for row in public_inputs {
             let mut p_last = rand[0];
             for (c, p_i) in row.iter().enumerate() {
                 p_last += E::from(*p_i) * rand[c + 1];
@@ -50,10 +50,10 @@ impl BusesAir {
         bus_p_last
     }
 
-    pub fn bus_logup_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]> + Clone, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: &I) -> E {
+    pub fn bus_logup_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]>, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: I) -> E {
         let mut bus_q_last = E::ZERO;
         let rand = aux_rand_elements.rand_elements();
-        for row in public_inputs.clone().into_iter() {
+        for row in public_inputs {
             let mut q_last = rand[0];
             for (c, p_i) in row.iter().enumerate() {
                 let p_i = *p_i;
@@ -102,8 +102,8 @@ impl Air for BusesAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
         let mut result = Vec::new();
-        let reduced_inputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs.iter());
-        let reduced_inputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.inputs.iter());
+        let reduced_inputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.inputs);
+        let reduced_inputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.inputs);
         result.push(Assertion::single(0, 0, reduced_inputs_multiset));
         result.push(Assertion::single(0, self.last_step(), E::ONE));
         result.push(Assertion::single(1, 0, reduced_inputs_logup));

--- a/air-script/tests/buses/buses_varlen_boundary_last.rs
+++ b/air-script/tests/buses/buses_varlen_boundary_last.rs
@@ -102,10 +102,12 @@ impl Air for BusesAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
         let mut result = Vec::new();
+        let reduced_outputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.outputs.iter());
+        let reduced_outputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs.iter());
         result.push(Assertion::single(0, 0, E::ONE));
+        result.push(Assertion::single(0, self.last_step(), reduced_outputs_multiset));
         result.push(Assertion::single(1, 0, E::ZERO));
-        result.push(Assertion::single(0, self.last_step(), Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.outputs.iter())));
-        result.push(Assertion::single(1, self.last_step(), Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs.iter())));
+        result.push(Assertion::single(1, self.last_step(), reduced_outputs_logup));
         result
     }
 

--- a/air-script/tests/buses/buses_varlen_boundary_last.rs
+++ b/air-script/tests/buses/buses_varlen_boundary_last.rs
@@ -37,10 +37,10 @@ impl BusesAir {
         self.trace_length() - self.context().num_transition_exemptions()
     }
 
-    pub fn bus_multiset_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]> + Clone, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: &I) -> E {
+    pub fn bus_multiset_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]>, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: I) -> E {
         let mut bus_p_last: E = E::ONE;
         let rand = aux_rand_elements.rand_elements();
-        for row in public_inputs.clone().into_iter() {
+        for row in public_inputs {
             let mut p_last = rand[0];
             for (c, p_i) in row.iter().enumerate() {
                 p_last += E::from(*p_i) * rand[c + 1];
@@ -50,10 +50,10 @@ impl BusesAir {
         bus_p_last
     }
 
-    pub fn bus_logup_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]> + Clone, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: &I) -> E {
+    pub fn bus_logup_boundary_varlen<'a, const N: usize, I: IntoIterator<Item = &'a [Felt; N]>, E: FieldElement<BaseField = Felt>>(aux_rand_elements: &AuxRandElements<E>, public_inputs: I) -> E {
         let mut bus_q_last = E::ZERO;
         let rand = aux_rand_elements.rand_elements();
-        for row in public_inputs.clone().into_iter() {
+        for row in public_inputs {
             let mut q_last = rand[0];
             for (c, p_i) in row.iter().enumerate() {
                 let p_i = *p_i;
@@ -102,8 +102,8 @@ impl Air for BusesAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
         let mut result = Vec::new();
-        let reduced_outputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.outputs.iter());
-        let reduced_outputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs.iter());
+        let reduced_outputs_multiset = Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.outputs);
+        let reduced_outputs_logup = Self::bus_logup_boundary_varlen(aux_rand_elements, &self.outputs);
         result.push(Assertion::single(0, 0, E::ONE));
         result.push(Assertion::single(0, self.last_step(), reduced_outputs_multiset));
         result.push(Assertion::single(1, 0, E::ZERO));

--- a/air/src/graph/mod.rs
+++ b/air/src/graph/mod.rs
@@ -120,6 +120,13 @@ impl AlgebraicGraph {
                     );
                     Ok((DEFAULT_SEGMENT, default_domain))
                 },
+                Value::PublicInputTable(_) => {
+                    assert!(
+                        !default_domain.is_integrity(),
+                        "unexpected access to public input table in integrity constraint"
+                    );
+                    Ok((DEFAULT_SEGMENT, default_domain))
+                },
                 Value::TraceAccess(trace_access) => {
                     let domain = if default_domain.is_boundary() {
                         assert_eq!(
@@ -172,7 +179,10 @@ impl AlgebraicGraph {
         // recursively walk the subgraph and compute the degree from the operation and child nodes
         match self.node(index).op() {
             Operation::Value(value) => match value {
-                Value::Constant(_) | Value::PublicInput(_) | Value::RandomValue(_) => 0,
+                Value::Constant(_)
+                | Value::PublicInput(_)
+                | Value::PublicInputTable(_)
+                | Value::RandomValue(_) => 0,
                 Value::TraceAccess(_) => 1,
                 Value::PeriodicColumn(pc) => {
                     cycles.insert(pc.name, pc.cycle);

--- a/air/src/ir/bus.rs
+++ b/air/src/ir/bus.rs
@@ -20,7 +20,7 @@ pub struct Bus {
 }
 
 /// Represents the boundaries of a bus, which can be either a public input table or an empty bus.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BusBoundary {
     /// A reference to a public input table.
     PublicInputTable(PublicInputTableAccess),
@@ -37,14 +37,21 @@ pub enum BusBoundary {
 pub struct PublicInputTableAccess {
     /// The name of the public input to bind
     pub table_name: Identifier,
-    /// The name of the bus
-    pub bus_name: Identifier,
     /// The number of columns in the public input table
     pub num_cols: usize,
+    /// The name of the bus
+    pub bus_name: Identifier,
+    /// The type of the bus
+    pub bus_type: BusType,
 }
 impl PublicInputTableAccess {
-    pub const fn new(table_name: Identifier, bus_name: Identifier, num_cols: usize) -> Self {
-        Self { table_name, num_cols, bus_name }
+    pub const fn new(
+        table_name: Identifier,
+        num_cols: usize,
+        bus_name: Identifier,
+        bus_type: BusType,
+    ) -> Self {
+        Self { table_name, num_cols, bus_name, bus_type }
     }
 }
 

--- a/air/src/ir/bus.rs
+++ b/air/src/ir/bus.rs
@@ -39,19 +39,12 @@ pub struct PublicInputTableAccess {
     pub table_name: Identifier,
     /// The number of columns in the public input table
     pub num_cols: usize,
-    /// The name of the bus
-    pub bus_name: Identifier,
     /// The type of the bus
     pub bus_type: BusType,
 }
 impl PublicInputTableAccess {
-    pub const fn new(
-        table_name: Identifier,
-        num_cols: usize,
-        bus_name: Identifier,
-        bus_type: BusType,
-    ) -> Self {
-        Self { table_name, num_cols, bus_name, bus_type }
+    pub const fn new(table_name: Identifier, num_cols: usize, bus_type: BusType) -> Self {
+        Self { table_name, num_cols, bus_type }
     }
 }
 

--- a/air/src/ir/value.rs
+++ b/air/src/ir/value.rs
@@ -16,6 +16,8 @@ pub enum Value {
     PeriodicColumn(PeriodicColumnAccess),
     /// A reference to a specific element of a given public input
     PublicInput(PublicInputAccess),
+    /// A reference to a specific public input table used as a boundary for one of the buses.
+    PublicInputTable(PublicInputTableAccess),
     /// A reference to the `random_values` array, specifically the element at the given index
     RandomValue(usize),
 }

--- a/air/src/passes/expand_buses.rs
+++ b/air/src/passes/expand_buses.rs
@@ -104,9 +104,9 @@ impl<'a> BusOpExpand<'a> {
             // Boundaries to PublicInputTable reference a value corresponding to the random
             // reduction of a public input table for a given bus type (multiset or logUp)
             BusBoundary::PublicInputTable(public_input_table_access) => {
-                ir
-                    .constraint_graph_mut()
-                    .insert_node(Operation::Value(crate::Value::PublicInputTable(*public_input_table_access)))
+                ir.constraint_graph_mut().insert_node(Operation::Value(
+                    crate::Value::PublicInputTable(*public_input_table_access),
+                ))
             },
             BusBoundary::Null => {
                 // The value of the constraint for an empty bus depends on the bus types (1 for
@@ -119,10 +119,9 @@ impl<'a> BusOpExpand<'a> {
                         .constraint_graph_mut()
                         .insert_node(Operation::Value(crate::Value::Constant(0))),
                 }
-
             },
             // Unconstrained boundaries do not require any constraints
-            BusBoundary::Unconstrained => { return },
+            BusBoundary::Unconstrained => return,
         };
         let bus_trace_access = TraceAccess::new(AUX_SEGMENT, bus_index, 0);
         let bus_access = ir

--- a/air/src/passes/expand_buses.rs
+++ b/air/src/passes/expand_buses.rs
@@ -100,41 +100,44 @@ impl<'a> BusOpExpand<'a> {
         boundary: Boundary,
         bus_index: usize,
     ) {
-        match bus_boundary {
-            // Boundaries to PublicInputTable should be handled later during codegen, as we cannot
-            // know at this point the length of the table, so we cannot generate the resulting
-            // constraint
-            BusBoundary::PublicInputTable(_public_input_table_access) => {},
-            // Unconstrained boundaries do not require any constraints
-            BusBoundary::Unconstrained => {},
+        let value = match bus_boundary {
+            // Boundaries to PublicInputTable reference a value corresponding to the random
+            // reduction of a public input table for a given bus type (multiset or logUp)
+            BusBoundary::PublicInputTable(public_input_table_access) => {
+                ir
+                    .constraint_graph_mut()
+                    .insert_node(Operation::Value(crate::Value::PublicInputTable(*public_input_table_access)))
+            },
             BusBoundary::Null => {
                 // The value of the constraint for an empty bus depends on the bus types (1 for
                 // multiset, 0 for logup)
-                let value = match bus_type {
+                match bus_type {
                     BusType::Multiset => ir
                         .constraint_graph_mut()
                         .insert_node(Operation::Value(crate::Value::Constant(1))),
                     BusType::Logup => ir
                         .constraint_graph_mut()
                         .insert_node(Operation::Value(crate::Value::Constant(0))),
-                };
+                }
 
-                let bus_trace_access = TraceAccess::new(AUX_SEGMENT, bus_index, 0);
-                let bus_access = ir
-                    .constraint_graph_mut()
-                    .insert_node(Operation::Value(crate::Value::TraceAccess(bus_trace_access)));
-
-                // Then, we enforce for instance the constraint `p.first = 1` or `q.first = 0` to
-                // have an empty bus initially
-                let root = ir.constraint_graph_mut().insert_node(Operation::Sub(bus_access, value));
-                let domain = match boundary {
-                    Boundary::First => ConstraintDomain::FirstRow,
-                    Boundary::Last => ConstraintDomain::LastRow,
-                };
-                // Store the generated constraint
-                ir.constraints.insert_constraint(AUX_SEGMENT, root, domain);
             },
-        }
+            // Unconstrained boundaries do not require any constraints
+            BusBoundary::Unconstrained => { return },
+        };
+        let bus_trace_access = TraceAccess::new(AUX_SEGMENT, bus_index, 0);
+        let bus_access = ir
+            .constraint_graph_mut()
+            .insert_node(Operation::Value(crate::Value::TraceAccess(bus_trace_access)));
+
+        // Then, we enforce for instance the constraint `p.first = 0/1` or `q.first = value` to
+        // have an empty bus initially or equal to the values given in a public input table.
+        let root = ir.constraint_graph_mut().insert_node(Operation::Sub(bus_access, value));
+        let domain = match boundary {
+            Boundary::First => ConstraintDomain::FirstRow,
+            Boundary::Last => ConstraintDomain::LastRow,
+        };
+        // Store the generated constraint
+        ir.constraints.insert_constraint(AUX_SEGMENT, root, domain);
     }
 
     /// Helper function to expand the integrity constraint of a multiset bus

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -592,8 +592,9 @@ fn build_bus_boundary(
             MirValue::PublicInputTable(public_input_table) => Ok(
                 crate::ir::BusBoundary::PublicInputTable(crate::ir::PublicInputTableAccess::new(
                     public_input_table.table_name,
-                    public_input_table.bus_name(),
                     public_input_table.num_cols,
+                    public_input_table.bus_name(),
+                    public_input_table.bus_type(),
                 )),
             ),
             // This represents an empty bus

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -593,7 +593,6 @@ fn build_bus_boundary(
                 crate::ir::BusBoundary::PublicInputTable(crate::ir::PublicInputTableAccess::new(
                     public_input_table.table_name,
                     public_input_table.num_cols,
-                    public_input_table.bus_name(),
                     public_input_table.bus_type(),
                 )),
             ),

--- a/codegen/ace/src/builder.rs
+++ b/codegen/ace/src/builder.rs
@@ -138,6 +138,9 @@ impl CircuitBuilder {
                 Value::PublicInput(pi) => self.layout.public_inputs[&pi.name]
                     .as_node(pi.index)
                     .expect("invalid public input access"),
+                Value::PublicInputTable(_) => {
+                    todo!("public input tables are not supported yet (see #399)")
+                },
                 Value::RandomValue(idx) => {
                     self.layout.random_values.as_node(*idx).expect("invalid random value index")
                 },

--- a/codegen/ace/src/tests/quotient.rs
+++ b/codegen/ace/src/tests/quotient.rs
@@ -66,6 +66,9 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
                     let idx = public[&access.name];
                     ace_vars.public[idx][access.index]
                 },
+                Value::PublicInputTable(_) => {
+                    todo!("public input tables are not supported yet (see #399)")
+                },
                 Value::RandomValue(idx) => ace_vars.rand[idx],
             },
             Operation::Add(l, r) => evals[usize::from(l)] + evals[usize::from(r)],

--- a/codegen/winterfell/src/air/boundary_constraints.rs
+++ b/codegen/winterfell/src/air/boundary_constraints.rs
@@ -78,12 +78,12 @@ fn add_aux_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
     // declare the result vector to be returned.
     func_body.line("let mut result = Vec::new();");
 
-    // Add expressions for evaluating the reduced public input table. Its expression is defined as 
+    // Add expressions for evaluating the reduced public input table. Its expression is defined as
     // `reduced_{TABLE_NAME}_{BUS_TYPE}`.
     // This ensures that if two busses of the same type are constrained at a boundary to the same
     // public input table, the codegen generates the same lines. These should easily be optimized
     // by the compiler.
-    // TODO: These values are constant across all rows and therefore can be computed only once 
+    // TODO: These values are constant across all rows and therefore can be computed only once
     //       before starting the constraint evaluation.
     let domains = [ConstraintDomain::FirstRow, ConstraintDomain::LastRow];
     for domain in domains {

--- a/codegen/winterfell/src/air/graph.rs
+++ b/codegen/winterfell/src/air/graph.rs
@@ -95,6 +95,13 @@ impl Codegen for Value {
             Value::PublicInput(air_ir::PublicInputAccess { name, index }) => {
                 format!("self.{name}[{index}]")
             },
+            Value::PublicInputTable(air_ir::PublicInputTableAccess {
+                table_name,
+                bus_type,
+                ..
+            }) => {
+                format!("reduced_{table_name}_{bus_type}")
+            },
             Value::RandomValue(idx) => {
                 format!("aux_rand_elements.rand_elements()[{idx}]")
             },

--- a/codegen/winterfell/src/air/graph.rs
+++ b/codegen/winterfell/src/air/graph.rs
@@ -98,7 +98,7 @@ impl Codegen for Value {
             Value::PublicInputTable(air_ir::PublicInputTableAccess {
                 table_name,
                 bus_type,
-                ..
+                num_cols: _,
             }) => {
                 format!("reduced_{table_name}_{bus_type}")
             },

--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -12,7 +12,7 @@ mod boundary_constraints;
 use boundary_constraints::{add_fn_get_assertions, add_fn_get_aux_assertions};
 
 mod transition_constraints;
-use air_ir::{Air, BusBoundary, BusType, ConstraintDomain, Identifier, TraceSegmentId};
+use air_ir::{Air, Bus, BusBoundary, BusType, ConstraintDomain, Identifier, TraceSegmentId};
 use transition_constraints::{add_fn_evaluate_aux_transition, add_fn_evaluate_transition};
 
 use super::{Impl, Scope};
@@ -267,12 +267,7 @@ fn add_constraint_degrees(
     func_body.line(format!("let {decl_name} = vec![{}];", degrees.join(", ")));
 }
 
-fn call_bus_boundary_varlen_pubinput(
-    ir: &Air,
-    bus_name: Identifier,
-    table_name: Identifier,
-) -> String {
-    let bus = ir.buses.get(&bus_name).expect("bus not found");
+fn call_bus_boundary_varlen_pubinput(bus: &Bus, table_name: Identifier) -> String {
     match bus.bus_type {
         BusType::Multiset => format!(
             "Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.{table_name}.iter())",

--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -113,15 +113,15 @@ fn impl_bus_multiset_boundary_varlen(base_impl: &mut Impl) {
         .new_fn("bus_multiset_boundary_varlen")
         .generic("'a")
         .generic("const N: usize")
-        .generic("I: IntoIterator<Item = &'a [Felt; N]> + Clone")
+        .generic("I: IntoIterator<Item = &'a [Felt; N]>")
         .generic("E: FieldElement<BaseField = Felt>")
         .arg("aux_rand_elements", "&AuxRandElements<E>")
-        .arg("public_inputs", "&I")
+        .arg("public_inputs", "I")
         .ret("E")
         .vis("pub")
         .line("let mut bus_p_last: E = E::ONE;")
         .line("let rand = aux_rand_elements.rand_elements();")
-        .line("for row in public_inputs.clone().into_iter() {")
+        .line("for row in public_inputs {")
         .line("    let mut p_last = rand[0];")
         .line("    for (c, p_i) in row.iter().enumerate() {")
         .line("        p_last += E::from(*p_i) * rand[c + 1];")
@@ -157,15 +157,15 @@ fn impl_bus_logup_boundary_varlen(base_impl: &mut Impl) {
         .new_fn("bus_logup_boundary_varlen")
         .generic("'a")
         .generic("const N: usize")
-        .generic("I: IntoIterator<Item = &'a [Felt; N]> + Clone")
+        .generic("I: IntoIterator<Item = &'a [Felt; N]>")
         .generic("E: FieldElement<BaseField = Felt>")
         .arg("aux_rand_elements", "&AuxRandElements<E>")
-        .arg("public_inputs", "&I")
+        .arg("public_inputs", "I")
         .ret("E")
         .vis("pub")
         .line("let mut bus_q_last = E::ZERO;")
         .line("let rand = aux_rand_elements.rand_elements();")
-        .line("for row in public_inputs.clone().into_iter() {")
+        .line("for row in public_inputs {")
         .line("    let mut q_last = rand[0];")
         .line("    for (c, p_i) in row.iter().enumerate() {")
         .line("        let p_i = *p_i;")
@@ -269,11 +269,11 @@ fn add_constraint_degrees(
 
 fn call_bus_boundary_varlen_pubinput(bus: &Bus, table_name: Identifier) -> String {
     match bus.bus_type {
-        BusType::Multiset => format!(
-            "Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.{table_name}.iter())",
-        ),
+        BusType::Multiset => {
+            format!("Self::bus_multiset_boundary_varlen(aux_rand_elements, &self.{table_name})",)
+        },
         BusType::Logup => {
-            format!("Self::bus_logup_boundary_varlen(aux_rand_elements, &self.{table_name}.iter())",)
+            format!("Self::bus_logup_boundary_varlen(aux_rand_elements, &self.{table_name})",)
         },
     }
 }

--- a/mir/src/ir/nodes/ops/value.rs
+++ b/mir/src/ir/nodes/ops/value.rs
@@ -1,4 +1,6 @@
-use air_parser::ast::{self, Identifier, QualifiedIdentifier, TraceColumnIndex, TraceSegmentId};
+use air_parser::ast::{
+    self, BusType, Identifier, QualifiedIdentifier, TraceColumnIndex, TraceSegmentId,
+};
 use miden_diagnostics::{SourceSpan, Spanned};
 
 use crate::ir::{BackLink, Builder, Bus, Child, Link, Node, Op, Owner, Singleton};
@@ -198,23 +200,38 @@ impl PublicInputAccess {
 pub struct PublicInputTableAccess {
     /// The name of the public input to bind
     pub table_name: Identifier,
-    /// The name of the bus to bind
+    /// The number of columns in the table
+    pub num_cols: usize,
+    /// The name of the bus to bind.
     /// The bus name is not always known at the time of instantiation,
     /// making it an Option allows setting it later.
     bus_name: Option<Identifier>,
-    /// The number of columns in the table
-    pub num_cols: usize,
+    /// The type of bus to bind (multiset or logUp).
+    /// The bus type is not always known at the time of instantiation,
+    /// making it an Option allows setting it later.
+    bus_type: Option<BusType>,
 }
 
 impl PublicInputTableAccess {
     pub const fn new(table_name: Identifier, num_cols: usize) -> Self {
-        Self { table_name, bus_name: None, num_cols }
+        Self {
+            table_name,
+            num_cols,
+            bus_name: None,
+            bus_type: None,
+        }
     }
     pub fn set_bus_name(&mut self, bus_name: Identifier) {
         self.bus_name = Some(bus_name);
     }
     pub fn bus_name(&self) -> Identifier {
         self.bus_name.expect("Bus name should have already been set")
+    }
+    pub fn set_bus_type(&mut self, bus_type: BusType) {
+        self.bus_type = Some(bus_type);
+    }
+    pub fn bus_type(&self) -> BusType {
+        self.bus_type.expect("Bus type should have already been set")
     }
 }
 

--- a/mir/src/ir/nodes/ops/value.rs
+++ b/mir/src/ir/nodes/ops/value.rs
@@ -202,10 +202,6 @@ pub struct PublicInputTableAccess {
     pub table_name: Identifier,
     /// The number of columns in the table
     pub num_cols: usize,
-    /// The name of the bus to bind.
-    /// The bus name is not always known at the time of instantiation,
-    /// making it an Option allows setting it later.
-    bus_name: Option<Identifier>,
     /// The type of bus to bind (multiset or logUp).
     /// The bus type is not always known at the time of instantiation,
     /// making it an Option allows setting it later.
@@ -214,18 +210,7 @@ pub struct PublicInputTableAccess {
 
 impl PublicInputTableAccess {
     pub const fn new(table_name: Identifier, num_cols: usize) -> Self {
-        Self {
-            table_name,
-            num_cols,
-            bus_name: None,
-            bus_type: None,
-        }
-    }
-    pub fn set_bus_name(&mut self, bus_name: Identifier) {
-        self.bus_name = Some(bus_name);
-    }
-    pub fn bus_name(&self) -> Identifier {
-        self.bus_name.expect("Bus name should have already been set")
+        Self { table_name, num_cols, bus_type: None }
     }
     pub fn set_bus_type(&mut self, bus_type: BusType) {
         self.bus_type = Some(bus_type);

--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -114,17 +114,14 @@ impl<'a> MirBuilder<'a> {
         }
 
         for bus in self.mir.constraint_graph().buses.values() {
-            let bus_name = bus.borrow().name();
             let bus_type = bus.borrow().bus_type;
             if let Some(ref mut mirvalue) = bus.borrow().get_first().as_value_mut() {
                 if let MirValue::PublicInputTable(ref mut first) = mirvalue.value.value {
-                    first.set_bus_name(bus_name);
                     first.set_bus_type(bus_type);
                 }
             }
             if let Some(ref mut mirvalue) = bus.borrow().get_last().as_value_mut() {
                 if let MirValue::PublicInputTable(ref mut last) = mirvalue.value.value {
-                    last.set_bus_name(bus_name);
                     last.set_bus_type(bus_type);
                 }
             }

--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -115,14 +115,17 @@ impl<'a> MirBuilder<'a> {
 
         for bus in self.mir.constraint_graph().buses.values() {
             let bus_name = bus.borrow().name();
+            let bus_type = bus.borrow().bus_type;
             if let Some(ref mut mirvalue) = bus.borrow().get_first().as_value_mut() {
                 if let MirValue::PublicInputTable(ref mut first) = mirvalue.value.value {
                     first.set_bus_name(bus_name);
+                    first.set_bus_type(bus_type);
                 }
             }
             if let Some(ref mut mirvalue) = bus.borrow().get_last().as_value_mut() {
                 if let MirValue::PublicInputTable(ref mut last) = mirvalue.value.value {
                     last.set_bus_name(bus_name);
+                    last.set_bus_type(bus_type);
                 }
             }
         }

--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -86,13 +86,22 @@ impl Bus {
         Self { span, name, bus_type }
     }
 }
-#[derive(Default, Copy, Hash, Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Copy, Hash, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BusType {
     /// A multiset bus
     #[default]
     Multiset,
     /// A logup bus
     Logup,
+}
+
+impl fmt::Display for BusType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Multiset => write!(f, "multiset"),
+            Self::Logup => write!(f, "logup"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Fixes #414

**Introduce new `ir::PublicInputTable` node**: This node corresponds to a randomly-reduced public input table.

**Optimize Winterfell bus boundary constraint generation**: Using the new `PublicInputTable` node, we can compute the reduced public input tables once, and handle all bus boundary constraints uniformly