### PR TITLE
Fix Typos in Comments and Documentation

### DIFF
--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -66,7 +66,7 @@ fn add_air_struct(scope: &mut Scope, ir: &Air, name: &str) {
     // add a method to get the variable length public inputs bus boundary constraints.
     let (mut add_bus_multiset_boundary_varlen, mut add_bus_logup_boundary_varlen) = (false, false);
     for bus in ir.buses.values() {
-        // Check which bus type is refering to variable length public inputs
+        // Check which bus type is referring to variable length public inputs
         let bus_constraints = [&bus.first, &bus.last];
         for fl in bus_constraints {
             if let BusBoundary::PublicInputTable(_) = fl {

--- a/mir/src/ir/nodes/ops/sub.rs
+++ b/mir/src/ir/nodes/ops/sub.rs
@@ -2,7 +2,7 @@ use miden_diagnostics::{SourceSpan, Spanned};
 
 use crate::ir::{BackLink, Builder, Child, Link, Node, Op, Owner, Parent, Singleton};
 
-/// A MIR operation to represent the substraction of two MIR ops, `lhs` and `rhs`
+/// A MIR operation to represent the subtraction of two MIR ops, `lhs` and `rhs`
 #[derive(Default, Clone, PartialEq, Eq, Debug, Hash, Builder, Spanned)]
 #[enum_wrapper(Op)]
 pub struct Sub {

--- a/mir/src/passes/unrolling.rs
+++ b/mir/src/passes/unrolling.rs
@@ -123,7 +123,7 @@ impl Pass for Unrolling<'_> {
     }
 }
 
-// For the first pass of Unrolling, we use a tweeked version of the Visitor trait,
+// For the first pass of Unrolling, we use a tweaked version of the Visitor trait,
 // each visit_*_bis function returns an Option<Link<Op>> instead of Result<(), CompileError>,
 // to mutate the nodes (e.g. modifying a Operation<Vectors> to Vector<Operations>)
 impl UnrollingFirstPass<'_> {


### PR DESCRIPTION


**Description:**  
This pull request corrects several minor typos in comments and documentation across the codebase for improved clarity and professionalism. No functional code changes were made.  
- Fixed "refering" → "referring"  
- Fixed "substraction" → "subtraction"  
- Fixed "tweeked" → "tweaked"