### PR TITLE
Add default compilation pipeline

### DIFF
--- a/air-script/README.md
+++ b/air-script/README.md
@@ -17,8 +17,7 @@ The compiler has four stages, which can be imported and used independently or to
 Example usage:
 
 ```Rust
-use air_ir::ast_to_air_pipeline;
-use air_script::{parse, Pass, WinterfellCodeGenerator};
+use air_script::{parse, compile, WinterfellCodeGenerator};
 use miden_diagnostics::{
     term::termcolor::ColorChoice, CodeMap, DefaultEmitter, DiagnosticsHandler,
 };
@@ -31,11 +30,8 @@ let diagnostics = DiagnosticsHandler::new(Default::default(), codemap.clone(), e
 // Parse into AST
 let ast = parse(&diagnostics, codemap, source.as_str()).expect("parsing failed");
 
-// Lower to MIR, then AIR
-let air = {
-   let mut pipeline = ast_to_air_pipeline(&diagnostics);
-   pipeline.run(ast).expect("lowering failed")
-};
+// Compile AST into AIR
+let air = compile(&diagnostics, ast).expect("compilation failed");
 
 // Generate Rust code targeting the Winterfell prover
 let code = WinterfellCodeGenerator.generate(&air).expect("codegen failed");

--- a/air-script/README.md
+++ b/air-script/README.md
@@ -17,6 +17,7 @@ The compiler has four stages, which can be imported and used independently or to
 Example usage:
 
 ```Rust
+use air_ir::ast_to_air_pipeline;
 use air_script::{parse, Pass, WinterfellCodeGenerator};
 use miden_diagnostics::{
     term::termcolor::ColorChoice, CodeMap, DefaultEmitter, DiagnosticsHandler,
@@ -30,20 +31,10 @@ let diagnostics = DiagnosticsHandler::new(Default::default(), codemap.clone(), e
 // Parse into AST
 let ast = parse(&diagnostics, codemap, source.as_str()).expect("parsing failed");
 
-// Lower to MIR
-let mir = {
-   let mut pipeline = air_parser::transforms::ConstantPropagation::new(&diagnostics)
-      .chain(mir::passes::AstToMir::new(&diagnostics))
-      .chain(mir::passes::Inlining::new(&diagnostics))
-      .chain(mir::passes::Unrolling::new(&diagnostics));
-   pipeline.run(ast).expect("lowering failed")
-};
-
-// Lower to AIR
+// Lower to MIR, then AIR
 let air = {
-   let mut pipeline = air_ir::passes::MirToAir::new(&diagnostics)
-      .chain(air_ir::passes::BusOpExpand::new(&diagnostics));
-   pipeline.run(mir).expect("lowering failed")
+   let mut pipeline = ast_to_air_pipeline(&diagnostics);
+   pipeline.run(ast).expect("lowering failed")
 };
 
 // Generate Rust code targeting the Winterfell prover

--- a/air-script/src/cli/transpile.rs
+++ b/air-script/src/cli/transpile.rs
@@ -1,7 +1,6 @@
 use std::{fs, path::PathBuf, sync::Arc};
 
-use air_ir::{CodeGenerator, CompileError, ast_to_air_pipeline};
-use air_pass::Pass;
+use air_ir::{CodeGenerator, CompileError, compile};
 use clap::{Args, ValueEnum};
 use miden_diagnostics::{
     CodeMap, DefaultEmitter, DiagnosticsHandler, term::termcolor::ColorChoice,
@@ -48,10 +47,7 @@ impl Transpile {
         // Parse from file to internal representation
         let air = air_parser::parse_file(&diagnostics, codemap, input_path)
             .map_err(CompileError::Parse)
-            .and_then(|ast| {
-                let mut pipeline = ast_to_air_pipeline(&diagnostics);
-                pipeline.run(ast)
-            });
+            .and_then(|program| compile(&diagnostics, program));
 
         match air {
             Ok(air) => {

--- a/air-script/src/cli/transpile.rs
+++ b/air-script/src/cli/transpile.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf, sync::Arc};
 
-use air_ir::{CodeGenerator, CompileError};
+use air_ir::{CodeGenerator, CompileError, ast_to_air_pipeline};
 use air_pass::Pass;
 use clap::{Args, ValueEnum};
 use miden_diagnostics::{
@@ -49,12 +49,7 @@ impl Transpile {
         let air = air_parser::parse_file(&diagnostics, codemap, input_path)
             .map_err(CompileError::Parse)
             .and_then(|ast| {
-                let mut pipeline = air_parser::transforms::ConstantPropagation::new(&diagnostics)
-                    .chain(mir::passes::AstToMir::new(&diagnostics))
-                    .chain(mir::passes::Inlining::new(&diagnostics))
-                    .chain(mir::passes::Unrolling::new(&diagnostics))
-                    .chain(air_ir::passes::MirToAir::new(&diagnostics))
-                    .chain(air_ir::passes::BusOpExpand::new(&diagnostics));
+                let mut pipeline = ast_to_air_pipeline(&diagnostics);
                 pipeline.run(ast)
             });
 

--- a/air-script/src/lib.rs
+++ b/air-script/src/lib.rs
@@ -1,4 +1,3 @@
 pub use air_codegen_winter::CodeGenerator as WinterfellCodeGenerator;
-pub use air_ir::{Air, CompileError, passes};
+pub use air_ir::{Air, CompileError, compile};
 pub use air_parser::{parse, parse_file, transforms};
-pub use air_pass::Pass;

--- a/air-script/tests/codegen/helpers.rs
+++ b/air-script/tests/codegen/helpers.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use air_ir::{CodeGenerator, CompileError, ast_to_air_pipeline};
-use air_pass::Pass;
+use air_ir::{CodeGenerator, CompileError};
+use air_script::compile;
 use miden_diagnostics::{
     CodeMap, DefaultEmitter, DiagnosticsHandler, term::termcolor::ColorChoice,
 };
@@ -26,10 +26,7 @@ impl Test {
         // Parse from file to internal representation
         let air = air_parser::parse_file(&diagnostics, codemap, &self.input_path)
             .map_err(CompileError::Parse)
-            .and_then(|ast| {
-                let mut pipeline = ast_to_air_pipeline(&diagnostics);
-                pipeline.run(ast)
-            })?;
+            .and_then(|program| compile(&diagnostics, program))?;
 
         let backend: Box<dyn CodeGenerator<Output = String>> = match target {
             Target::Winterfell => Box::new(air_codegen_winter::CodeGenerator),

--- a/air-script/tests/codegen/helpers.rs
+++ b/air-script/tests/codegen/helpers.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use air_ir::{CodeGenerator, CompileError};
+use air_ir::{CodeGenerator, CompileError, ast_to_air_pipeline};
 use air_pass::Pass;
 use miden_diagnostics::{
     CodeMap, DefaultEmitter, DiagnosticsHandler, term::termcolor::ColorChoice,
@@ -27,12 +27,7 @@ impl Test {
         let air = air_parser::parse_file(&diagnostics, codemap, &self.input_path)
             .map_err(CompileError::Parse)
             .and_then(|ast| {
-                let mut pipeline = air_parser::transforms::ConstantPropagation::new(&diagnostics)
-                    .chain(mir::passes::AstToMir::new(&diagnostics))
-                    .chain(mir::passes::Inlining::new(&diagnostics))
-                    .chain(mir::passes::Unrolling::new(&diagnostics))
-                    .chain(air_ir::passes::MirToAir::new(&diagnostics))
-                    .chain(air_ir::passes::BusOpExpand::new(&diagnostics));
+                let mut pipeline = ast_to_air_pipeline(&diagnostics);
                 pipeline.run(ast)
             })?;
 

--- a/air/README.md
+++ b/air/README.md
@@ -14,11 +14,8 @@ Example usage:
 // parse the source string to a Result containing the AST or an Error
 let ast = parse(source.as_str()).expect("Parsing failed");
 
-// Create the compilation pipeline needed to translate the AST to the MIR and then the AIR
-let mut pipeline = ast_to_air_pipeline(&diagnostics);
-
-// process the AST and the MIR to get a Result containing the AIR or a CompileError
-let air = pipeline.run(ast)
+// Compile AST into AIR
+let air = compile(&diagnostics, ast).expect("compilation failed");
 ```
 
 ## AirIR

--- a/air/README.md
+++ b/air/README.md
@@ -14,13 +14,8 @@ Example usage:
 // parse the source string to a Result containing the AST or an Error
 let ast = parse(source.as_str()).expect("Parsing failed");
 
-// Create the compilation pipeline needed to translate the AST to AIR
-let pipeline = air_parser::transforms::ConstantPropagation::new(&diagnostics)
-  .chain(mir::passes::AstToMir::new(&diagnostics))
-  .chain(mir::passes::Inlining::new(&diagnostics))
-  .chain(mir::passes::Unrolling::new(&diagnostics))
-  .chain(air_ir::passes::MirToAir::new(&diagnostics))
-  .chain(air_ir::passes::BusOpExpand::new(&diagnostics));
+// Create the compilation pipeline needed to translate the AST to the MIR and then the AIR
+let mut pipeline = ast_to_air_pipeline(&diagnostics);
 
 // process the AST and the MIR to get a Result containing the AIR or a CompileError
 let air = pipeline.run(ast)

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -5,7 +5,9 @@ pub mod passes;
 #[cfg(test)]
 mod tests;
 
-use miden_diagnostics::{Diagnostic, ToDiagnostic};
+use air_parser::ast::Program;
+use air_pass::Pass;
+use miden_diagnostics::{Diagnostic, DiagnosticsHandler, ToDiagnostic};
 use mir::ir::Mir;
 
 pub use self::{
@@ -13,6 +15,25 @@ pub use self::{
     graph::{AlgebraicGraph, Node, NodeIndex},
     ir::*,
 };
+
+/// Creates a pipeline of passes that transforms an AST into AIR.
+pub fn ast_to_air_pipeline<'a>(
+    diagnostics: &DiagnosticsHandler,
+) -> impl Pass<Input<'a> = Program, Output<'a> = Air, Error = CompileError> {
+    // Note: Commented out code to remove if we go with the other approach below
+    /*air_parser::transforms::ConstantPropagation::new(diagnostics)
+    .chain(mir::passes::AstToMir::new(diagnostics))
+    .chain(mir::passes::Inlining::new(diagnostics))
+    .chain(mir::passes::Unrolling::new(diagnostics))
+    .chain(crate::passes::MirToAir::new(diagnostics))
+    .chain(crate::passes::BusOpExpand::new(diagnostics))*/
+
+    let ast_passes = air_parser::AstPasses::new(diagnostics);
+    let mir_passes = mir::MirPasses::new(diagnostics);
+    let air_ir_passes = crate::AirPasses::new(diagnostics);
+
+    ast_passes.chain(mir_passes).chain(air_ir_passes)
+}
 
 /// Abstracts the various passes done on the AIR representation of the program.
 pub struct AirPasses<'a> {

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -6,12 +6,36 @@ pub mod passes;
 mod tests;
 
 use miden_diagnostics::{Diagnostic, ToDiagnostic};
+use mir::ir::Mir;
 
 pub use self::{
     codegen::CodeGenerator,
     graph::{AlgebraicGraph, Node, NodeIndex},
     ir::*,
 };
+
+/// Abstracts the various passes done on the AIR representation of the program.
+pub struct AirPasses<'a> {
+    diagnostics: &'a DiagnosticsHandler,
+}
+
+impl<'a> AirPasses<'a> {
+    pub fn new(diagnostics: &'a DiagnosticsHandler) -> Self {
+        Self { diagnostics }
+    }
+}
+
+impl Pass for AirPasses<'_> {
+    type Input<'a> = Mir;
+    type Output<'a> = Air;
+    type Error = CompileError;
+
+    fn run<'a>(&mut self, input: Self::Input<'a>) -> Result<Self::Output<'a>, Self::Error> {
+        let mut passes = passes::MirToAir::new(self.diagnostics)
+            .chain(passes::BusOpExpand::new(self.diagnostics));
+        passes.run(input)
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum CompileError {

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -16,6 +16,12 @@ pub use self::{
     ir::*,
 };
 
+/// Compiles an AirScript program from the the parsed AST to the AIR
+pub fn compile(diagnostics: &DiagnosticsHandler, program: Program) -> Result<Air, CompileError> {
+    let mut pipeline = ast_to_air_pipeline(diagnostics);
+    pipeline.run(program)
+}
+
 /// Creates a pipeline of passes that transforms an AST into AIR.
 pub fn ast_to_air_pipeline<'a>(
     diagnostics: &DiagnosticsHandler,

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -26,14 +26,6 @@ pub fn compile(diagnostics: &DiagnosticsHandler, program: Program) -> Result<Air
 pub fn ast_to_air_pipeline<'a>(
     diagnostics: &DiagnosticsHandler,
 ) -> impl Pass<Input<'a> = Program, Output<'a> = Air, Error = CompileError> {
-    // Note: Commented out code to remove if we go with the other approach below
-    /*air_parser::transforms::ConstantPropagation::new(diagnostics)
-    .chain(mir::passes::AstToMir::new(diagnostics))
-    .chain(mir::passes::Inlining::new(diagnostics))
-    .chain(mir::passes::Unrolling::new(diagnostics))
-    .chain(crate::passes::MirToAir::new(diagnostics))
-    .chain(crate::passes::BusOpExpand::new(diagnostics))*/
-
     let ast_passes = air_parser::AstPasses::new(diagnostics);
     let mir_passes = mir::MirPasses::new(diagnostics);
     let air_ir_passes = crate::AirPasses::new(diagnostics);

--- a/air/src/tests/boundary_constraints.rs
+++ b/air/src/tests/boundary_constraints.rs
@@ -1,4 +1,4 @@
-use super::{compile, expect_diagnostic};
+use super::{compile_from_source, expect_diagnostic};
 
 #[test]
 fn boundary_constraints() {
@@ -18,7 +18,7 @@ fn boundary_constraints() {
         enf clk' = clk + 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]

--- a/air/src/tests/buses.rs
+++ b/air/src/tests/buses.rs
@@ -1,4 +1,4 @@
-use super::{compile, expect_diagnostic};
+use super::{compile_from_source, expect_diagnostic};
 
 #[test]
 fn buses_in_boundary_constraints() {
@@ -29,7 +29,7 @@ fn buses_in_boundary_constraints() {
         enf a = 0;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn buses_in_integrity_constraints() {
         q.remove(1, 2) with 2;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 // Tests that should return errors

--- a/air/src/tests/constant.rs
+++ b/air/src/tests/constant.rs
@@ -1,4 +1,4 @@
-use super::{compile, expect_diagnostic};
+use super::{compile_from_source, expect_diagnostic};
 
 #[test]
 fn boundary_constraint_with_constants() {
@@ -21,7 +21,7 @@ fn boundary_constraint_with_constants() {
         enf clk' = clk - 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn integrity_constraint_with_constants() {
         enf clk' = clk + A + B[1] - C[1][2];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]

--- a/air/src/tests/evaluators.rs
+++ b/air/src/tests/evaluators.rs
@@ -1,4 +1,4 @@
-use super::compile;
+use super::compile_from_source;
 
 #[test]
 fn simple_evaluator() {
@@ -24,7 +24,7 @@ fn simple_evaluator() {
         enf advance_clock([clk]);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn evaluator_with_variables() {
         enf advance_clock([clk]);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn ev_call_inside_evaluator_with_main() {
         enf enforce_all_constraints([clk]);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -110,5 +110,5 @@ fn ev_fn_call_with_column_group() {
         enf clk_selectors([s, clk]);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }

--- a/air/src/tests/integrity_constraints/comprehension/constraint_comprehension.rs
+++ b/air/src/tests/integrity_constraints/comprehension/constraint_comprehension.rs
@@ -1,4 +1,4 @@
-use super::super::compile;
+use super::super::compile_from_source;
 
 #[test]
 fn constraint_comprehension() {
@@ -17,7 +17,7 @@ fn constraint_comprehension() {
         enf c = d for (c, d) in (c, d);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -37,5 +37,5 @@ fn ic_comprehension_with_selectors() {
         enf c = d for (c, d) in (c, d) when !fmp[0];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }

--- a/air/src/tests/integrity_constraints/comprehension/list_comprehension.rs
+++ b/air/src/tests/integrity_constraints/comprehension/list_comprehension.rs
@@ -1,4 +1,4 @@
-use super::super::{compile, expect_diagnostic};
+use super::super::{compile_from_source, expect_diagnostic};
 
 #[test]
 fn list_comprehension() {
@@ -18,7 +18,7 @@ fn list_comprehension() {
         enf clk = x[1];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn lc_with_const_exp() {
         enf clk = y[1] + z[1];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn lc_with_two_lists() {
         enf clk = diff[0];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn lc_with_two_slices() {
         enf clk = diff[1];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -124,7 +124,7 @@ fn lc_with_multiple_lists() {
         enf a = x[0] + x[1] + x[2];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]

--- a/air/src/tests/integrity_constraints/mod.rs
+++ b/air/src/tests/integrity_constraints/mod.rs
@@ -1,4 +1,4 @@
-use super::{compile, expect_diagnostic};
+use super::{compile_from_source, expect_diagnostic};
 
 mod comprehension;
 
@@ -19,7 +19,7 @@ fn integrity_constraints() {
         enf clk' = clk + 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn ic_using_parens() {
         enf clk' = (clk + 1);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn ic_op_mul() {
         enf clk' * clk = 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn ic_op_exp() {
         enf clk'^2 - clk = 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]

--- a/air/src/tests/list_folding.rs
+++ b/air/src/tests/list_folding.rs
@@ -1,4 +1,4 @@
-use super::compile;
+use super::compile_from_source;
 
 #[test]
 fn list_folding_on_const() {
@@ -20,7 +20,7 @@ fn list_folding_on_const() {
         enf clk = y - x;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn list_folding_on_variable() {
         enf clk = z - y;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn list_folding_on_vector() {
         enf clk = y - x;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn list_folding_on_lc() {
         enf clk = y - x;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -110,5 +110,5 @@ fn list_folding_in_lc() {
         enf clk = y[0];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }

--- a/air/src/tests/mod.rs
+++ b/air/src/tests/mod.rs
@@ -18,6 +18,7 @@ use air_pass::Pass;
 use miden_diagnostics::{CodeMap, DiagnosticsConfig, DiagnosticsHandler, Verbosity};
 
 pub use crate::CompileError;
+use crate::ast_to_air_pipeline;
 
 pub fn compile(source: &str) -> Result<crate::Air, ()> {
     let compiler = Compiler::default();
@@ -77,13 +78,7 @@ impl Compiler {
         air_parser::parse(&self.diagnostics, self.codemap.clone(), source)
             .map_err(CompileError::Parse)
             .and_then(|ast| {
-                let mut pipeline =
-                    air_parser::transforms::ConstantPropagation::new(&self.diagnostics)
-                        .chain(mir::passes::AstToMir::new(&self.diagnostics))
-                        .chain(mir::passes::Inlining::new(&self.diagnostics))
-                        .chain(mir::passes::Unrolling::new(&self.diagnostics))
-                        .chain(crate::passes::MirToAir::new(&self.diagnostics))
-                        .chain(crate::passes::BusOpExpand::new(&self.diagnostics));
+                let mut pipeline = ast_to_air_pipeline(&self.diagnostics);
                 pipeline.run(ast)
             })
     }

--- a/air/src/tests/mod.rs
+++ b/air/src/tests/mod.rs
@@ -19,7 +19,7 @@ use miden_diagnostics::{CodeMap, DiagnosticsConfig, DiagnosticsHandler, Verbosit
 pub use crate::CompileError;
 use crate::compile;
 
-pub fn compile(source: &str) -> Result<crate::Air, ()> {
+pub fn compile_from_source(source: &str) -> Result<crate::Air, ()> {
     let compiler = Compiler::default();
     match compiler.compile(source) {
         Ok(air) => Ok(air),

--- a/air/src/tests/mod.rs
+++ b/air/src/tests/mod.rs
@@ -14,11 +14,10 @@ mod variables;
 
 use std::sync::Arc;
 
-use air_pass::Pass;
 use miden_diagnostics::{CodeMap, DiagnosticsConfig, DiagnosticsHandler, Verbosity};
 
 pub use crate::CompileError;
-use crate::ast_to_air_pipeline;
+use crate::compile;
 
 pub fn compile(source: &str) -> Result<crate::Air, ()> {
     let compiler = Compiler::default();
@@ -77,10 +76,7 @@ impl Compiler {
     pub fn compile(&self, source: &str) -> Result<crate::Air, CompileError> {
         air_parser::parse(&self.diagnostics, self.codemap.clone(), source)
             .map_err(CompileError::Parse)
-            .and_then(|ast| {
-                let mut pipeline = ast_to_air_pipeline(&self.diagnostics);
-                pipeline.run(ast)
-            })
+            .and_then(|program| compile(&self.diagnostics, program))
     }
 }
 

--- a/air/src/tests/pub_inputs.rs
+++ b/air/src/tests/pub_inputs.rs
@@ -1,4 +1,4 @@
-use super::compile;
+use super::compile_from_source;
 
 #[test]
 fn bc_with_public_inputs() {
@@ -17,5 +17,5 @@ fn bc_with_public_inputs() {
         enf clk' = clk - 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }

--- a/air/src/tests/selectors.rs
+++ b/air/src/tests/selectors.rs
@@ -1,4 +1,4 @@
-use super::compile;
+use super::compile_from_source;
 
 #[test]
 fn single_selector() {
@@ -18,7 +18,7 @@ fn single_selector() {
         enf clk' = clk when s[0];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn chained_selectors() {
         enf clk' = clk when (s[0] & !s[1]) | !s[2]';
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn multiconstraint_selectors() {
         };
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -93,7 +93,7 @@ fn selectors_in_evaluators() {
         enf evaluator_with_selector([s[0], clk]);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn multiple_selectors_in_evaluators() {
         enf evaluator_with_selector([s[0], s[1], clk]);
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn selector_with_evaluator_call() {
         enf unchanged([clk]) when s[0] & !s[1];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -186,5 +186,5 @@ fn selectors_inside_match() {
         };
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }

--- a/air/src/tests/trace.rs
+++ b/air/src/tests/trace.rs
@@ -1,4 +1,4 @@
-use super::{compile, expect_diagnostic};
+use super::{compile_from_source, expect_diagnostic};
 
 #[test]
 fn trace_columns_index_access() {
@@ -17,7 +17,7 @@ fn trace_columns_index_access() {
         enf $main[0]' - $main[1] = 0;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn trace_cols_groups() {
         enf a[0]' = a[1] - 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]

--- a/air/src/tests/variables.rs
+++ b/air/src/tests/variables.rs
@@ -1,4 +1,4 @@
-use super::{compile, expect_diagnostic};
+use super::{compile_from_source, expect_diagnostic};
 
 #[test]
 fn let_scalar_constant_in_boundary_constraint() {
@@ -18,7 +18,7 @@ fn let_scalar_constant_in_boundary_constraint() {
         enf clk' = clk + 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn let_vector_constant_in_boundary_constraint() {
         enf clk' = clk + 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn multi_constraint_nested_let_with_expressions_in_boundary_constraint() {
         enf clk' = clk + 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn let_scalar_constant_in_boundary_constraint_both_domains() {
         enf clk' = clk + 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn nested_let_with_expressions_in_integrity_constraint() {
         enf c[0][0] = 1;
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -158,7 +158,7 @@ fn nested_let_with_vector_access_in_integrity_constraint() {
         enf clk' = c[0] + e[2][0] + e[0][1];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }
 
 #[test]
@@ -395,5 +395,5 @@ fn trace_binding_access_in_integrity_constraint() {
         enf clk' = clk + a[0];
     }";
 
-    assert!(compile(source).is_ok());
+    assert!(compile_from_source(source).is_ok());
 }

--- a/codegen/ace/src/tests/mod.rs
+++ b/codegen/ace/src/tests/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use air_ir::Air;
+use air_ir::{Air, ast_to_air_pipeline};
 use miden_diagnostics::{
     CodeMap, DefaultEmitter, DiagnosticsHandler, term::termcolor::ColorChoice,
 };
@@ -25,12 +25,7 @@ pub fn generate_circuit(source: &str) -> (Air, Circuit, Node) {
     let air = air_parser::parse(&diagnostics, code_map, source)
         .map_err(air_ir::CompileError::Parse)
         .and_then(|ast| {
-            let mut pipeline = air_parser::transforms::ConstantPropagation::new(&diagnostics)
-                .chain(mir::passes::AstToMir::new(&diagnostics))
-                .chain(mir::passes::Inlining::new(&diagnostics))
-                .chain(mir::passes::Unrolling::new(&diagnostics))
-                .chain(air_ir::passes::MirToAir::new(&diagnostics))
-                .chain(air_ir::passes::BusOpExpand::new(&diagnostics));
+            let mut pipeline = ast_to_air_pipeline(&diagnostics);
             pipeline.run(ast)
         })
         .expect("lowering failed");

--- a/codegen/ace/src/tests/mod.rs
+++ b/codegen/ace/src/tests/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use air_ir::{Air, ast_to_air_pipeline};
+use air_ir::{Air, compile};
 use miden_diagnostics::{
     CodeMap, DefaultEmitter, DiagnosticsHandler, term::termcolor::ColorChoice,
 };
@@ -16,18 +16,13 @@ mod random;
 
 /// Generates an ACE circuit and its root index from an AirScript program.
 pub fn generate_circuit(source: &str) -> (Air, Circuit, Node) {
-    use air_pass::Pass;
-
     let code_map = Arc::new(CodeMap::new());
     let emitter = Arc::new(DefaultEmitter::new(ColorChoice::Auto));
     let diagnostics = DiagnosticsHandler::new(Default::default(), code_map.clone(), emitter);
 
     let air = air_parser::parse(&diagnostics, code_map, source)
         .map_err(air_ir::CompileError::Parse)
-        .and_then(|ast| {
-            let mut pipeline = ast_to_air_pipeline(&diagnostics);
-            pipeline.run(ast)
-        })
+        .and_then(|program| compile(&diagnostics, program))
         .expect("lowering failed");
 
     let (root, circuit) = build_ace_circuit(&air).expect("codegen failed");

--- a/codegen/winterfell/README.md
+++ b/codegen/winterfell/README.md
@@ -16,13 +16,8 @@ Example usage:
 // parse the source string to a Result containing the AST or an Error
 let ast = parse(source.as_str()).expect("Parsing failed");
 
-// Create the compilation pipeline needed to translate the AST to AIR
-let pipeline = air_parser::transforms::ConstantPropagation::new(&diagnostics)
-  .chain(mir::passes::AstToMir::new(&diagnostics))
-  .chain(mir::passes::Inlining::new(&diagnostics))
-  .chain(mir::passes::Unrolling::new(&diagnostics))
-  .chain(air_ir::passes::MirToAir::new(&diagnostics))
-  .chain(air_ir::passes::BusOpExpand::new(&diagnostics));
+// Create the compilation pipeline needed to translate the AST to the MIR and then the AIR
+let mut pipeline = ast_to_air_pipeline(&diagnostics);
 
 // process the AST and the MIR to get a Result containing the AIR or a CompileError
 let air = pipeline.run(ast)

--- a/codegen/winterfell/README.md
+++ b/codegen/winterfell/README.md
@@ -16,11 +16,8 @@ Example usage:
 // parse the source string to a Result containing the AST or an Error
 let ast = parse(source.as_str()).expect("Parsing failed");
 
-// Create the compilation pipeline needed to translate the AST to the MIR and then the AIR
-let mut pipeline = ast_to_air_pipeline(&diagnostics);
-
-// process the AST and the MIR to get a Result containing the AIR or a CompileError
-let air = pipeline.run(ast)
+// Compile AST into AIR
+let air = compile(&diagnostics, ast).expect("compilation failed");
 
 // generate Rust code targeting the Winterfell prover
 let rust_code = CodeGenerator::new(&air);

--- a/mir/src/lib.rs
+++ b/mir/src/lib.rs
@@ -5,9 +5,36 @@ pub mod passes;
 #[cfg(test)]
 mod tests;
 
-use miden_diagnostics::{Diagnostic, ToDiagnostic};
+use air_parser::ast::Program;
+use air_pass::Pass;
+use miden_diagnostics::{Diagnostic, DiagnosticsHandler, ToDiagnostic};
 
 pub use self::codegen::CodeGenerator;
+use crate::ir::Mir;
+
+/// Abstracts the various passes done on the MIR representation of the program.
+pub struct MirPasses<'a> {
+    diagnostics: &'a DiagnosticsHandler,
+}
+
+impl<'a> MirPasses<'a> {
+    pub fn new(diagnostics: &'a DiagnosticsHandler) -> Self {
+        Self { diagnostics }
+    }
+}
+
+impl Pass for MirPasses<'_> {
+    type Input<'a> = Program;
+    type Output<'a> = Mir;
+    type Error = CompileError;
+
+    fn run<'a>(&mut self, input: Self::Input<'a>) -> Result<Self::Output<'a>, Self::Error> {
+        let mut passes = passes::AstToMir::new(self.diagnostics)
+            .chain(passes::Inlining::new(self.diagnostics))
+            .chain(passes::Unrolling::new(self.diagnostics));
+        passes.run(input)
+    }
+}
 
 /// Error type that can be returned during the Mir passes
 #[derive(Debug, thiserror::Error)]

--- a/mir/src/tests/mod.rs
+++ b/mir/src/tests/mod.rs
@@ -112,11 +112,8 @@ impl Compiler {
         air_parser::parse(&self.diagnostics, self.codemap.clone(), source)
             .map_err(CompileError::Parse)
             .and_then(|ast| {
-                let mut pipeline =
-                    air_parser::transforms::ConstantPropagation::new(&self.diagnostics)
-                        .chain(crate::passes::AstToMir::new(&self.diagnostics))
-                        .chain(crate::passes::Inlining::new(&self.diagnostics))
-                        .chain(crate::passes::Unrolling::new(&self.diagnostics));
+                let mut pipeline = air_parser::AstPasses::new(&self.diagnostics)
+                    .chain(crate::MirPasses::new(&self.diagnostics));
                 pipeline.run(ast)
             })
     }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -10,6 +10,7 @@ pub mod transforms;
 
 use std::{path::Path, sync::Arc};
 
+use air_pass::Pass;
 use miden_diagnostics::{CodeMap, DiagnosticsHandler};
 
 pub use self::{
@@ -17,6 +18,29 @@ pub use self::{
     sema::{LexicalScope, SemanticAnalysisError},
     symbols::Symbol,
 };
+use crate::ast::Program;
+
+/// Abstracts the various passes done on the AST representation of the program.
+pub struct AstPasses<'a> {
+    diagnostics: &'a DiagnosticsHandler,
+}
+
+impl<'a> AstPasses<'a> {
+    pub fn new(diagnostics: &'a DiagnosticsHandler) -> Self {
+        Self { diagnostics }
+    }
+}
+
+impl Pass for AstPasses<'_> {
+    type Input<'a> = Program;
+    type Output<'a> = Program;
+    type Error = SemanticAnalysisError;
+
+    fn run<'a>(&mut self, input: Self::Input<'a>) -> Result<Self::Output<'a>, Self::Error> {
+        let mut passes = transforms::ConstantPropagation::new(self.diagnostics);
+        passes.run(input)
+    }
+}
 
 /// Parses the provided source and returns the AST.
 pub fn parse(


### PR DESCRIPTION
This PR aims to close https://github.com/0xMiden/air-script/issues/426.

In `air-script/src/lib.rs`, I export the function `ast_to_air_pipeline` that provides a default compilation pipeline.
In its implementation, I had two approaches:
- the first one that simply chained all the passes together (commented out) and returned them
- the second one, that abstracts the passes for each compilation stage (AST / MIR / AIR). It chains black-boxed `AstPasses`, `MirPasses`, `AirPasses`. This is useful as if we need to update the passes for a given crate, we do not need to update code outside it. However, the borrow check wouldn't let me neatly chain the passes there (as Pass is not dyn-compatible), so I had to create new structs (`AstPasses`, `MirPasses`, `AirPasses`) and implement the Pass trait on them manually.

Which implementation should we keep?