### PR TITLE
Define TraceSegment enum for Main and Aux traces

### DIFF
--- a/air/src/graph/mod.rs
+++ b/air/src/graph/mod.rs
@@ -103,29 +103,29 @@ impl AlgebraicGraph {
         // recursively walk the subgraph and infer the trace segment and domain
         match self.node(index).op() {
             Operation::Value(value) => match value {
-                Value::Constant(_) => Ok((DEFAULT_SEGMENT, default_domain)),
-                Value::RandomValue(_) => Ok((AUX_SEGMENT, default_domain)),
+                Value::Constant(_) => Ok((TraceSegmentId::Main, default_domain)),
+                Value::RandomValue(_) => Ok((TraceSegmentId::Aux, default_domain)),
                 Value::PeriodicColumn(_) => {
                     assert!(
                         !default_domain.is_boundary(),
                         "unexpected access to periodic column in boundary constraint"
                     );
                     // the default domain for [IntegrityConstraints] is `EveryRow`
-                    Ok((DEFAULT_SEGMENT, ConstraintDomain::EveryRow))
+                    Ok((TraceSegmentId::Main, ConstraintDomain::EveryRow))
                 },
                 Value::PublicInput(_) => {
                     assert!(
                         !default_domain.is_integrity(),
                         "unexpected access to public input in integrity constraint"
                     );
-                    Ok((DEFAULT_SEGMENT, default_domain))
+                    Ok((TraceSegmentId::Main, default_domain))
                 },
                 Value::PublicInputTable(_) => {
                     assert!(
                         !default_domain.is_integrity(),
                         "unexpected access to public input table in integrity constraint"
                     );
-                    Ok((DEFAULT_SEGMENT, default_domain))
+                    Ok((TraceSegmentId::Main, default_domain))
                 },
                 Value::TraceAccess(trace_access) => {
                     let domain = if default_domain.is_boundary() {
@@ -145,7 +145,10 @@ impl AlgebraicGraph {
                 let (lhs_segment, lhs_domain) = self.node_details(lhs, default_domain)?;
                 let (rhs_segment, rhs_domain) = self.node_details(rhs, default_domain)?;
 
-                let trace_segment = lhs_segment.max(rhs_segment);
+                let trace_segment = match (lhs_segment, rhs_segment) {
+                    (TraceSegmentId::Aux, _) | (_, TraceSegmentId::Aux) => TraceSegmentId::Aux,
+                    _ => TraceSegmentId::Main,
+                };
                 let domain = lhs_domain.merge(rhs_domain)?;
 
                 Ok((trace_segment, domain))

--- a/air/src/graph/mod.rs
+++ b/air/src/graph/mod.rs
@@ -145,10 +145,7 @@ impl AlgebraicGraph {
                 let (lhs_segment, lhs_domain) = self.node_details(lhs, default_domain)?;
                 let (rhs_segment, rhs_domain) = self.node_details(rhs, default_domain)?;
 
-                let trace_segment = match (lhs_segment, rhs_segment) {
-                    (TraceSegmentId::Aux, _) | (_, TraceSegmentId::Aux) => TraceSegmentId::Aux,
-                    _ => TraceSegmentId::Main,
-                };
+                let trace_segment = lhs_segment.max(rhs_segment);
                 let domain = lhs_domain.merge(rhs_domain)?;
 
                 Ok((trace_segment, domain))

--- a/air/src/ir/constraints.rs
+++ b/air/src/ir/constraints.rs
@@ -26,11 +26,11 @@ pub struct Constraints {
     /// Constraint roots for all boundary constraints against the execution trace, by trace
     /// segment, where boundary constraints are any constraints that apply to either the first
     /// or the last row of the trace.
-    boundary_constraints: Vec<Vec<ConstraintRoot>>,
+    boundary_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
     /// Constraint roots for all integrity constraints against the execution trace, by trace
     /// segment, where integrity constraints are any constraints that apply to every row or
     /// every frame.
-    integrity_constraints: Vec<Vec<ConstraintRoot>>,
+    integrity_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
     /// A directed acyclic graph which represents all of the constraints and their subexpressions.
     graph: AlgebraicGraph,
 }
@@ -38,8 +38,8 @@ impl Constraints {
     /// Constructs a new [Constraints] graph from the given parts
     pub const fn new(
         graph: AlgebraicGraph,
-        boundary_constraints: Vec<Vec<ConstraintRoot>>,
-        integrity_constraints: Vec<Vec<ConstraintRoot>>,
+        boundary_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
+        integrity_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
     ) -> Self {
         Self {
             graph,
@@ -50,11 +50,7 @@ impl Constraints {
 
     /// Returns the number of boundary constraints applied against the specified trace segment.
     pub fn num_boundary_constraints(&self, trace_segment: TraceSegmentId) -> usize {
-        if self.boundary_constraints.len() <= trace_segment {
-            return 0;
-        }
-
-        self.boundary_constraints[trace_segment].len()
+        self.boundary_constraints.get(&trace_segment).map_or(0, |v| v.len())
     }
 
     /// Returns the set of boundary constraints for the given trace segment.
@@ -62,11 +58,7 @@ impl Constraints {
     /// Each boundary constraint is represented by a [ConstraintRoot] which is
     /// the root of the subgraph representing the constraint within the [AlgebraicGraph]
     pub fn boundary_constraints(&self, trace_segment: TraceSegmentId) -> &[ConstraintRoot] {
-        if self.boundary_constraints.len() <= trace_segment {
-            return &[];
-        }
-
-        &self.boundary_constraints[trace_segment]
+        self.boundary_constraints.get(&trace_segment).map_or(&[], |v| v.as_slice())
     }
 
     /// Returns a vector of the degrees of the integrity constraints for the specified trace
@@ -75,14 +67,11 @@ impl Constraints {
         &self,
         trace_segment: TraceSegmentId,
     ) -> Vec<IntegrityConstraintDegree> {
-        if self.integrity_constraints.len() <= trace_segment {
-            return vec![];
-        }
-
-        self.integrity_constraints[trace_segment]
-            .iter()
-            .map(|entry_index| self.graph.degree(entry_index.node_index()))
-            .collect()
+        self.integrity_constraints.get(&trace_segment).map_or(vec![], |v| {
+            v.iter()
+                .map(|entry_index| self.graph.degree(entry_index.node_index()))
+                .collect()
+        })
     }
 
     /// Returns the set of integrity constraints for the given trace segment.
@@ -90,11 +79,7 @@ impl Constraints {
     /// Each integrity constraint is represented by a [ConstraintRoot] which is
     /// the root of the subgraph representing the constraint within the [AlgebraicGraph]
     pub fn integrity_constraints(&self, trace_segment: TraceSegmentId) -> &[ConstraintRoot] {
-        if self.integrity_constraints.len() <= trace_segment {
-            return &[];
-        }
-
-        &self.integrity_constraints[trace_segment]
+        self.integrity_constraints.get(&trace_segment).map_or(&[], |v| v.as_slice())
     }
 
     /// Inserts a new constraint against `trace_segment`, using the provided `root` and `domain`
@@ -106,15 +91,9 @@ impl Constraints {
     ) {
         let root = ConstraintRoot::new(root, domain);
         if domain.is_boundary() {
-            if self.boundary_constraints.len() <= trace_segment {
-                self.boundary_constraints.resize(trace_segment + 1, vec![]);
-            }
-            self.boundary_constraints[trace_segment].push(root);
+            self.boundary_constraints.entry(trace_segment).or_default().push(root);
         } else {
-            if self.integrity_constraints.len() <= trace_segment {
-                self.integrity_constraints.resize(trace_segment + 1, vec![]);
-            }
-            self.integrity_constraints[trace_segment].push(root);
+            self.integrity_constraints.entry(trace_segment).or_default().push(root);
         }
     }
 

--- a/air/src/ir/mod.rs
+++ b/air/src/ir/mod.rs
@@ -22,10 +22,6 @@ pub use self::{
     value::{PeriodicColumnAccess, PublicInputAccess, Value},
 };
 
-/// The default segment against which a constraint is applied is the main trace segment.
-pub const DEFAULT_SEGMENT: TraceSegmentId = 0;
-/// The auxiliary trace segment.
-pub const AUX_SEGMENT: TraceSegmentId = 1;
 /// The offset of the "current" row during constraint evaluation.
 pub const CURRENT_ROW: usize = 0;
 /// The minimum cycle length of a periodic column

--- a/air/src/ir/trace.rs
+++ b/air/src/ir/trace.rs
@@ -20,13 +20,4 @@ impl TraceAccess {
     pub const fn new(segment: TraceSegmentId, column: TraceColumnIndex, row_offset: usize) -> Self {
         Self { segment, column, row_offset }
     }
-
-    /// Creates a new [TraceAccess] with a new column index that is updated according to the
-    /// provided offsets. All other data is left unchanged.
-    pub fn clone_with_offsets(&self, offsets: &[Vec<usize>]) -> Self {
-        Self {
-            column: offsets[self.segment][self.column],
-            ..*self
-        }
-    }
 }

--- a/air/src/passes/expand_buses.rs
+++ b/air/src/passes/expand_buses.rs
@@ -1,11 +1,10 @@
-use air_parser::ast::{Boundary, BusType};
+use air_parser::ast::{Boundary, BusType, TraceSegmentId};
 use air_pass::Pass;
 use miden_diagnostics::DiagnosticsHandler;
 use mir::ir::BusOpKind;
 
 use crate::{
-    AUX_SEGMENT, Air, BusBoundary, BusOp, CompileError, ConstraintDomain, NodeIndex, Operation,
-    TraceAccess,
+    Air, BusBoundary, BusOp, CompileError, ConstraintDomain, NodeIndex, Operation, TraceAccess,
 };
 
 pub struct BusOpExpand<'a> {
@@ -42,8 +41,8 @@ impl Pass for BusOpExpand<'_> {
 
             let bus_ops = bus.bus_ops.clone();
 
-            let bus_trace_access = TraceAccess::new(AUX_SEGMENT, bus_index, 0);
-            let bus_trace_access_with_offset = TraceAccess::new(AUX_SEGMENT, bus_index, 1);
+            let bus_trace_access = TraceAccess::new(TraceSegmentId::Aux, bus_index, 0);
+            let bus_trace_access_with_offset = TraceAccess::new(TraceSegmentId::Aux, bus_index, 1);
 
             let bus_access = ir
                 .constraint_graph_mut()
@@ -126,7 +125,7 @@ impl<'a> BusOpExpand<'a> {
             // Unconstrained boundaries do not require any constraints
             BusBoundary::Unconstrained => return,
         };
-        let bus_trace_access = TraceAccess::new(AUX_SEGMENT, bus_index, 0);
+        let bus_trace_access = TraceAccess::new(TraceSegmentId::Aux, bus_index, 0);
         let bus_access = ir
             .constraint_graph_mut()
             .insert_node(Operation::Value(crate::Value::TraceAccess(bus_trace_access)));
@@ -139,7 +138,7 @@ impl<'a> BusOpExpand<'a> {
             Boundary::Last => ConstraintDomain::LastRow,
         };
         // Store the generated constraint
-        ir.constraints.insert_constraint(AUX_SEGMENT, root, domain);
+        ir.constraints.insert_constraint(TraceSegmentId::Aux, root, domain);
     }
 
     /// Helper function to expand the integrity constraint of a multiset bus
@@ -235,7 +234,8 @@ impl<'a> BusOpExpand<'a> {
         // 6. Create the resulting constraint and insert it into the graph
         let root = graph.insert_node(Operation::Sub(p_prod, p_prime_prod));
 
-        ir.constraints.insert_constraint(AUX_SEGMENT, root, ConstraintDomain::EveryRow);
+        ir.constraints
+            .insert_constraint(TraceSegmentId::Aux, root, ConstraintDomain::EveryRow);
     }
 
     /// Helper function to expand the integrity constraint of a logup bus
@@ -372,6 +372,7 @@ impl<'a> BusOpExpand<'a> {
 
         // 5. Create the resulting constraint
         let root = graph.insert_node(Operation::Sub(q_term, q_prime_term));
-        ir.constraints.insert_constraint(AUX_SEGMENT, root, ConstraintDomain::EveryRow);
+        ir.constraints
+            .insert_constraint(TraceSegmentId::Aux, root, ConstraintDomain::EveryRow);
     }
 }

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -34,16 +34,20 @@ impl Pass for MirToAir<'_> {
 
         let buses = mir.constraint_graph().buses.clone();
 
-        if mir.trace_columns.len() != 1 {
-            panic!("Expected one trace segment, but found multiple: {:?}", mir.trace_columns);
-        }
+        assert!(
+            mir.trace_columns.len() == 1,
+            "Expected one trace segment, but found: {:?}",
+            mir.trace_columns
+        );
         let main_trace_segment = mir.trace_columns.first().unwrap();
-        if main_trace_segment.id != TraceSegmentId::Main {
-            panic!(
-                "Expected trace segment to be the main segment, but found: {:?}",
-                main_trace_segment.id
-            );
-        }
+
+        assert_eq!(
+            main_trace_segment.id,
+            TraceSegmentId::Main,
+            "Expected trace segment to be the main segment, but found: {:?}",
+            main_trace_segment.id
+        );
+
         let mut trace_columns = BTreeMap::new();
         trace_columns.insert(main_trace_segment.id, main_trace_segment.clone());
 
@@ -58,7 +62,10 @@ impl Pass for MirToAir<'_> {
             let aux_trace_segment = TraceSegment::new(
                 SourceSpan::default(),
                 TraceSegmentId::Aux,
-                Identifier::new(SourceSpan::default(), Symbol::new(TraceSegmentId::Aux as u32)),
+                Identifier::new(
+                    SourceSpan::default(),
+                    Symbol::new(TraceSegmentId::Aux.index() as u32),
+                ),
                 bus_raw_bindings,
             );
             for binding in aux_trace_segment.bindings.iter() {
@@ -445,7 +452,7 @@ impl AirBuilder<'_> {
                 if let Some(prev) = self
                     .trace_columns
                     .get_mut(&trace_access.segment)
-                    .unwrap()
+                    .expect("Boundary constraint on an unknown trace segment")
                     .mark_constrained(lhs_span, trace_access.column, boundary.kind)
                 {
                     self.diagnostics

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -34,33 +34,40 @@ impl Pass for MirToAir<'_> {
 
         let buses = mir.constraint_graph().buses.clone();
 
-        let mut trace_columns = mir.trace_columns.clone();
+        if mir.trace_columns.len() != 1 {
+            panic!("Expected one trace segment, but found multiple: {:?}", mir.trace_columns);
+        }
+        let main_trace_segment = mir.trace_columns.first().unwrap();
+        if main_trace_segment.id != TraceSegmentId::Main {
+            panic!(
+                "Expected trace segment to be the main segment, but found: {:?}",
+                main_trace_segment.id
+            );
+        }
+        let mut trace_columns = BTreeMap::new();
+        trace_columns.insert(main_trace_segment.id, main_trace_segment.clone());
 
         let mut bus_bindings_map = BTreeMap::new();
         if !buses.is_empty() {
             let bus_raw_bindings: Vec<_> = buses
                 .keys()
-                .map(|k| Span::new(k.span(), (Identifier::new(k.span(), k.name()), AUX_SEGMENT)))
+                .map(|k| Span::new(k.span(), (Identifier::new(k.span(), k.name()), 1)))
                 .collect();
 
             // Add buses as `aux` trace columns
             let aux_trace_segment = TraceSegment::new(
                 SourceSpan::default(),
-                AUX_SEGMENT,
-                Identifier::new(SourceSpan::default(), Symbol::new(AUX_SEGMENT as u32)),
+                TraceSegmentId::Aux,
+                Identifier::new(SourceSpan::default(), Symbol::new(TraceSegmentId::Aux as u32)),
                 bus_raw_bindings,
             );
             for binding in aux_trace_segment.bindings.iter() {
                 bus_bindings_map.insert(binding.name.unwrap(), binding.offset);
             }
-            if trace_columns.len() == 1 {
-                trace_columns.push(aux_trace_segment);
-            } else {
-                panic!("Expected only one trace segment, but found multiple: {trace_columns:?}",);
-            }
+            trace_columns.insert(aux_trace_segment.id, aux_trace_segment);
         }
 
-        air.trace_segment_widths = trace_columns.iter().map(|ts| ts.size as u16).collect();
+        air.trace_segment_widths = trace_columns.values().map(|ts| ts.size as u16).collect();
         air.num_random_values = mir.num_random_values;
         air.periodic_columns = mir.periodic_columns.clone();
         air.public_inputs = mir.public_inputs.clone();
@@ -98,7 +105,7 @@ impl Pass for MirToAir<'_> {
 struct AirBuilder<'a> {
     diagnostics: &'a DiagnosticsHandler,
     air: &'a mut Air,
-    trace_columns: Vec<TraceSegment>,
+    trace_columns: BTreeMap<TraceSegmentId, TraceSegment>,
     bus_bindings_map: BTreeMap<Identifier, usize>,
 }
 
@@ -264,7 +271,7 @@ impl AirBuilder<'_> {
                         let name = bus_access.bus.borrow().deref().name();
                         let column = self.bus_bindings_map.get(&name).unwrap();
                         crate::ir::Value::TraceAccess(crate::ir::TraceAccess {
-                            segment: AUX_SEGMENT,
+                            segment: TraceSegmentId::Aux,
                             column: *column,
                             row_offset: bus_access.row_offset,
                         })
@@ -320,7 +327,7 @@ impl AirBuilder<'_> {
                         let name = bus_access.bus.borrow().deref().name();
                         let column = self.bus_bindings_map.get(&name).unwrap();
                         crate::ir::Value::TraceAccess(crate::ir::TraceAccess {
-                            segment: AUX_SEGMENT,
+                            segment: TraceSegmentId::Aux,
                             column: *column,
                             row_offset: offset,
                         })
@@ -422,8 +429,11 @@ impl AirBuilder<'_> {
                         let bus = bus_access.bus;
                         let name = bus.borrow().deref().name();
                         let column = self.bus_bindings_map.get(&name).unwrap();
-                        let trace_access =
-                            mir::ir::TraceAccess::new(AUX_SEGMENT, *column, bus_access.row_offset);
+                        let trace_access = mir::ir::TraceAccess::new(
+                            TraceSegmentId::Aux,
+                            *column,
+                            bus_access.row_offset,
+                        );
                         (trace_access, lhs_span)
                     },
                     _ => unreachable!(
@@ -432,11 +442,12 @@ impl AirBuilder<'_> {
                     ), // Raise diag
                 };
 
-                if let Some(prev) = self.trace_columns[trace_access.segment].mark_constrained(
-                    lhs_span,
-                    trace_access.column,
-                    boundary.kind,
-                ) {
+                if let Some(prev) = self
+                    .trace_columns
+                    .get_mut(&trace_access.segment)
+                    .unwrap()
+                    .mark_constrained(lhs_span, trace_access.column, boundary.kind)
+                {
                     self.diagnostics
                         .diagnostic(Severity::Error)
                         .with_message("overlapping boundary constraints")
@@ -468,8 +479,8 @@ impl AirBuilder<'_> {
                         // trace segment inference defaults to the lowest segment (the main trace)
                         // and is adjusted according to the use of random
                         // values and trace columns.
-                        let lhs_segment_name = self.trace_columns[lhs_segment].name;
-                        let rhs_segment_name = self.trace_columns[rhs_segment].name;
+                        let lhs_segment_name = self.trace_columns[&lhs_segment].name;
+                        let rhs_segment_name = self.trace_columns[&rhs_segment].name;
                         self.diagnostics.diagnostic(Severity::Error)
                                     .with_message("invalid boundary constraint")
                                     .with_primary_label(lhs_span, format!("this constrains a column in the '{lhs_segment_name}' trace segment"))

--- a/codegen/ace/src/layout.rs
+++ b/codegen/ace/src/layout.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, ops::Range};
 
 use air_ir::{
     Air, Identifier, PublicInput, PublicInputAccess, PublicInputTableAccess, TraceAccess,
+    TraceSegmentId,
 };
 
 use crate::circuit::Node;
@@ -207,12 +208,12 @@ impl Layout {
     /// Input node associated with a trace variable.
     pub fn trace_access_node(&self, trace_access: &TraceAccess) -> Option<Node> {
         let TraceAccess { segment, column, row_offset } = *trace_access;
-        // We should only be able to access the main and aux segments.
-        if segment > 1 {
-            return None;
+        let segment_index = match segment {
+            TraceSegmentId::Main => 0,
+            TraceSegmentId::Aux => 1,
         };
         let segments_in_row = self.trace_segments.get(row_offset)?;
-        let segment_region = segments_in_row.get(segment)?;
+        let segment_region = segments_in_row.get(segment_index)?;
         segment_region.as_node(column)
     }
 

--- a/codegen/ace/src/layout.rs
+++ b/codegen/ace/src/layout.rs
@@ -2,7 +2,6 @@ use std::{collections::BTreeMap, ops::Range};
 
 use air_ir::{
     Air, Identifier, PublicInput, PublicInputAccess, PublicInputTableAccess, TraceAccess,
-    TraceSegmentId,
 };
 
 use crate::circuit::Node;
@@ -208,11 +207,8 @@ impl Layout {
     /// Input node associated with a trace variable.
     pub fn trace_access_node(&self, trace_access: &TraceAccess) -> Option<Node> {
         let TraceAccess { segment, column, row_offset } = *trace_access;
-        let segment_index = match segment {
-            TraceSegmentId::Main => 0,
-            TraceSegmentId::Aux => 1,
-        };
         let segments_in_row = self.trace_segments.get(row_offset)?;
+        let segment_index = segment.index();
         let segment_region = segments_in_row.get(segment_index)?;
         segment_region.as_node(column)
     }

--- a/codegen/ace/src/lib.rs
+++ b/codegen/ace/src/lib.rs
@@ -7,7 +7,7 @@ mod layout;
 #[cfg(test)]
 mod tests;
 
-use air_ir::{Air, ConstraintDomain};
+use air_ir::{Air, ConstraintDomain, TraceSegmentId};
 pub use mir::ir::QuadFelt;
 
 use crate::{
@@ -61,7 +61,7 @@ pub fn build_ace_circuit(air: &Air) -> anyhow::Result<(AceNode, AceCircuit)> {
     // ACE chiplet
     let mut cb = CircuitBuilder::new(air);
 
-    let segments = [0, 1];
+    let segments = [TraceSegmentId::Main, TraceSegmentId::Aux];
     let integrity_roots: Vec<_> = segments
         .iter()
         .flat_map(|&seg| air.integrity_constraints(seg))

--- a/codegen/ace/src/tests/quotient.rs
+++ b/codegen/ace/src/tests/quotient.rs
@@ -66,10 +66,7 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
             Operation::Value(v) => match v {
                 Value::Constant(c) => QuadFelt::from(Felt::new(c)),
                 Value::TraceAccess(access) => {
-                    let segment_index = match access.segment {
-                        TraceSegmentId::Main => 0,
-                        TraceSegmentId::Aux => 1,
-                    };
+                    let segment_index = access.segment.index();
                     ace_vars.segments[access.row_offset][segment_index][access.column]
                 },
                 Value::PeriodicColumn(access) => periodic[&access.name],

--- a/codegen/ace/src/tests/quotient.rs
+++ b/codegen/ace/src/tests/quotient.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use air_ir::{Air, ConstraintDomain, NodeIndex, Operation, Value};
+use air_ir::{Air, ConstraintDomain, NodeIndex, Operation, TraceSegmentId, Value};
 use miden_core::Felt;
 use winter_math::FieldElement;
 
@@ -66,7 +66,11 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
             Operation::Value(v) => match v {
                 Value::Constant(c) => QuadFelt::from(Felt::new(c)),
                 Value::TraceAccess(access) => {
-                    ace_vars.segments[access.row_offset][access.segment][access.column]
+                    let segment_index = match access.segment {
+                        TraceSegmentId::Main => 0,
+                        TraceSegmentId::Aux => 1,
+                    };
+                    ace_vars.segments[access.row_offset][segment_index][access.column]
                 },
                 Value::PeriodicColumn(access) => periodic[&access.name],
                 Value::PublicInput(access) => {
@@ -98,7 +102,7 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
         std::iter::successors(Some(QuadFelt::ONE), move |alpha_prev| Some(*alpha_prev * alpha));
 
     // Evaluate linear-combination of integrity constraints.
-    let integrity: QuadFelt = [0, 1]
+    let integrity: QuadFelt = [TraceSegmentId::Main, TraceSegmentId::Aux]
         .into_iter()
         .flat_map(|segment| {
             air.constraints.integrity_constraints(segment).iter().map(|c| {
@@ -113,7 +117,7 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
         .fold(QuadFelt::ZERO, |acc, (eval, alpha_pow)| acc + eval * alpha_pow);
 
     // Evaluate linear-combination of integrity constraints for the first row
-    let boundary_first = [0, 1]
+    let boundary_first = [TraceSegmentId::Main, TraceSegmentId::Aux]
         .into_iter()
         .flat_map(|segment| {
             air.constraints
@@ -129,7 +133,7 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
         .fold(QuadFelt::ZERO, |acc, (eval, alpha_pow)| acc + eval * alpha_pow);
 
     // Evaluate linear-combination of integrity constraints for the last row
-    let boundary_last = [0, 1]
+    let boundary_last = [TraceSegmentId::Main, TraceSegmentId::Aux]
         .into_iter()
         .flat_map(|segment| {
             air.constraints

--- a/codegen/winterfell/src/air/boundary_constraints.rs
+++ b/codegen/winterfell/src/air/boundary_constraints.rs
@@ -46,8 +46,6 @@ pub(super) fn add_fn_get_aux_assertions(impl_ref: &mut Impl, ir: &Air) {
 /// Declares a result vector and adds assertions for boundary constraints to it for the main
 /// trace segment
 fn add_main_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
-    let elem_type = ElemType::Base;
-
     // declare the result vector to be returned.
     func_body.line("let mut result = Vec::new();");
 
@@ -57,7 +55,7 @@ fn add_main_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
             split_boundary_constraint(ir.constraint_graph(), constraint.node_index());
         debug_assert_eq!(trace_access.segment, TraceSegmentId::Main);
 
-        let expr_root_string = expr_root.to_string(ir, elem_type, TraceSegmentId::Main);
+        let expr_root_string = expr_root.to_string(ir, ElemType::Base, TraceSegmentId::Main);
 
         let assertion = format!(
             "result.push(Assertion::single({}, {}, {}));",
@@ -73,8 +71,6 @@ fn add_main_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
 /// Declares a result vector and adds assertions for boundary constraints to it for the aux
 /// trace segment (used for buses boundary constraints for variable length public inputs)
 fn add_aux_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
-    let elem_type = ElemType::Ext;
-
     // declare the result vector to be returned.
     func_body.line("let mut result = Vec::new();");
 
@@ -105,7 +101,7 @@ fn add_aux_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
             split_boundary_constraint(ir.constraint_graph(), constraint.node_index());
         debug_assert_eq!(trace_access.segment, TraceSegmentId::Aux);
 
-        let expr_root_string = expr_root.to_string(ir, elem_type, TraceSegmentId::Aux);
+        let expr_root_string = expr_root.to_string(ir, ElemType::Ext, TraceSegmentId::Aux);
 
         let assertion = format!(
             "result.push(Assertion::single({}, {}, {}));",

--- a/codegen/winterfell/src/air/boundary_constraints.rs
+++ b/codegen/winterfell/src/air/boundary_constraints.rs
@@ -1,6 +1,8 @@
 use core::panic;
 
-use air_ir::{Air, AlgebraicGraph, ConstraintDomain, NodeIndex, Operation, TraceAccess};
+use air_ir::{
+    Air, AlgebraicGraph, ConstraintDomain, NodeIndex, Operation, TraceAccess, TraceSegmentId,
+};
 
 use super::{Codegen, ElemType, Impl};
 use crate::air::call_bus_boundary_varlen_pubinput;
@@ -45,18 +47,17 @@ pub(super) fn add_fn_get_aux_assertions(impl_ref: &mut Impl, ir: &Air) {
 /// trace segment
 fn add_main_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
     let elem_type = ElemType::Base;
-    let main_trace_segment = 0;
 
     // declare the result vector to be returned.
     func_body.line("let mut result = Vec::new();");
 
     // add the main boundary constraints
-    for constraint in ir.boundary_constraints(main_trace_segment) {
+    for constraint in ir.boundary_constraints(TraceSegmentId::Main) {
         let (trace_access, expr_root) =
             split_boundary_constraint(ir.constraint_graph(), constraint.node_index());
-        debug_assert_eq!(trace_access.segment, main_trace_segment);
+        debug_assert_eq!(trace_access.segment, TraceSegmentId::Main);
 
-        let expr_root_string = expr_root.to_string(ir, elem_type, main_trace_segment);
+        let expr_root_string = expr_root.to_string(ir, elem_type, TraceSegmentId::Main);
 
         let assertion = format!(
             "result.push(Assertion::single({}, {}, {}));",
@@ -73,7 +74,6 @@ fn add_main_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
 /// trace segment (used for buses boundary constraints for variable length public inputs)
 fn add_aux_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
     let elem_type = ElemType::Ext;
-    let aux_trace_segment = 1;
 
     // declare the result vector to be returned.
     func_body.line("let mut result = Vec::new();");
@@ -86,8 +86,11 @@ fn add_aux_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
     // TODO: These values are constant across all rows and therefore can be computed only once
     //       before starting the constraint evaluation.
     for access in ir.reduced_public_input_table_accesses() {
-        let boundary_value =
-            air_ir::Value::PublicInputTable(access).to_string(ir, ElemType::Ext, 0);
+        let boundary_value = air_ir::Value::PublicInputTable(access).to_string(
+            ir,
+            ElemType::Ext,
+            TraceSegmentId::Aux,
+        );
         let expr_root_string = call_bus_boundary_varlen_pubinput(access);
 
         let boundary_value_init = format!("let {boundary_value} = {expr_root_string};");
@@ -97,12 +100,12 @@ fn add_aux_trace_assertions(func_body: &mut codegen::Function, ir: &Air) {
 
     // add the boundary constraints that have already be expanded in the algebraic graph
     // (currently, empty buses constraints)
-    for constraint in ir.boundary_constraints(aux_trace_segment) {
+    for constraint in ir.boundary_constraints(TraceSegmentId::Aux) {
         let (trace_access, expr_root) =
             split_boundary_constraint(ir.constraint_graph(), constraint.node_index());
-        debug_assert_eq!(trace_access.segment, aux_trace_segment);
+        debug_assert_eq!(trace_access.segment, TraceSegmentId::Aux);
 
-        let expr_root_string = expr_root.to_string(ir, elem_type, aux_trace_segment);
+        let expr_root_string = expr_root.to_string(ir, elem_type, TraceSegmentId::Aux);
 
         let assertion = format!(
             "result.push(Assertion::single({}, {}, {}));",

--- a/codegen/winterfell/src/air/graph.rs
+++ b/codegen/winterfell/src/air/graph.rs
@@ -32,7 +32,7 @@ impl Codegen for IntegrityConstraintDegree {
 
 impl Codegen for TraceAccess {
     fn to_string(&self, _ir: &Air, _elem_type: ElemType, trace_segment: TraceSegmentId) -> String {
-        let frame = if self.segment == 0 { "main" } else { "aux" };
+        let frame = self.segment.to_string();
         let row_offset = match self.row_offset {
             0 => {
                 format!("current[{}]", self.column)
@@ -42,7 +42,7 @@ impl Codegen for TraceAccess {
             },
             _ => panic!("Winterfell doesn't support row offsets greater than 1."),
         };
-        if self.segment == 0 && self.segment != trace_segment {
+        if self.segment == TraceSegmentId::Main && self.segment != trace_segment {
             format!("E::from({frame}_{row_offset})")
         } else {
             format!("{frame}_{row_offset}")

--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -216,13 +216,16 @@ fn add_fn_new(impl_ref: &mut Impl, ir: &Air) {
         .ret("Self");
 
     // define the integrity constraint degrees of the main trace `main_degrees`.
-    add_constraint_degrees(new, ir, 0, "main_degrees");
+    add_constraint_degrees(new, ir, TraceSegmentId::Main, "main_degrees");
 
     // define the integrity constraint degrees of the aux trace `aux_degrees`.
-    add_constraint_degrees(new, ir, 1, "aux_degrees");
+    add_constraint_degrees(new, ir, TraceSegmentId::Aux, "aux_degrees");
 
     // define the number of main trace boundary constraints `num_main_assertions`.
-    new.line(format!("let num_main_assertions = {};", ir.num_boundary_constraints(0)));
+    new.line(format!(
+        "let num_main_assertions = {};",
+        ir.num_boundary_constraints(TraceSegmentId::Main)
+    ));
 
     // define the number of aux trace boundary constraints `num_aux_assertions`.
     new.line(format!("let num_aux_assertions = {};", num_bus_boundary_constraints(ir)));

--- a/codegen/winterfell/src/air/transition_constraints.rs
+++ b/codegen/winterfell/src/air/transition_constraints.rs
@@ -22,7 +22,7 @@ pub(super) fn add_fn_evaluate_transition(impl_ref: &mut Impl, ir: &Air) {
     evaluate_transition.line("let main_next = frame.next();");
 
     // output the constraints.
-    add_constraints(evaluate_transition, ir, 0);
+    add_constraints(evaluate_transition, ir, TraceSegmentId::Main);
 }
 
 /// Adds an implementation of the "evaluate_aux_transition" method to the referenced Air
@@ -48,7 +48,7 @@ pub(super) fn add_fn_evaluate_aux_transition(impl_ref: &mut Impl, ir: &Air) {
     evaluate_aux_transition.line("let aux_next = aux_frame.next();");
 
     // output the constraints.
-    add_constraints(evaluate_aux_transition, ir, 1);
+    add_constraints(evaluate_aux_transition, ir, TraceSegmentId::Aux);
 }
 
 /// Iterates through the integrity constraints in the IR, and appends a line of generated code to

--- a/mir/src/ir/quad_eval.rs
+++ b/mir/src/ir/quad_eval.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, hash::Hash, ops::Deref};
 
+use air_parser::ast::TraceSegmentId;
 use miden_core::{Felt, QuadExtension};
 use rand::{distr::Uniform, prelude::*};
 use winter_math::{FieldElement, StarkField};
@@ -98,7 +99,7 @@ impl RandomInputs {
                     // yet evaluated, we will randomly generate values for
                     // this trace access, but also for all previous indices.
                     MirValue::TraceAccess(trace_access) => match trace_access.segment {
-                        0 => {
+                        TraceSegmentId::Main => {
                             let index = trace_access.column * 2 + trace_access.row_offset;
                             Ok(query_indexed_cur_eval(&mut self.rng, &mut self.main_trace, index))
                         },
@@ -147,7 +148,7 @@ impl RandomInputs {
                         // Use accessor offset instead of the trace_access row_offset
                         let index = trace_access.column * 2 + a.offset;
                         match trace_access.segment {
-                            0 => {
+                            TraceSegmentId::Main => {
                                 return Ok(query_indexed_cur_eval(
                                     &mut self.rng,
                                     &mut self.main_trace,

--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -1,7 +1,11 @@
 use core::panic;
 use std::ops::Deref;
 
-use air_parser::{LexicalScope, ast, ast::AccessType, symbols};
+use air_parser::{
+    LexicalScope,
+    ast::{self, AccessType, TraceSegmentId},
+    symbols,
+};
 use air_pass::Pass;
 use miden_diagnostics::{DiagnosticsHandler, Severity, SourceSpan, Span, Spanned};
 
@@ -1281,10 +1285,10 @@ impl<'a> MirBuilder<'a> {
     // Check assumptions, probably this assumed that the inlining pass did some work
     fn trace_access(&self, access: &ast::SymbolAccess) -> Option<TraceAccess> {
         let id = access.name.as_ref();
-        for (i, segment) in self.trace_columns.iter().enumerate() {
+        if let Some(segment) = self.trace_columns.first() {
             if segment.name == id {
                 if let AccessType::Index(column) = access.access_type {
-                    return Some(TraceAccess::new(i, column, access.offset));
+                    return Some(TraceAccess::new(TraceSegmentId::Main, column, access.offset));
                 } else {
                     // This should have been caught earlier during compilation
                     unreachable!(
@@ -1304,11 +1308,6 @@ impl<'a> MirBuilder<'a> {
                         binding.offset + extra_offset,
                         access.offset,
                     )),
-                    // This should have been caught earlier during compilation
-                    /*_ => unreachable!(
-                        "unexpected trace access type encountered during lowering: {:#?}",
-                        access
-                    ),*/
                     _ => None,
                 };
             }

--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -1284,35 +1284,44 @@ impl<'a> MirBuilder<'a> {
 
     // Check assumptions, probably this assumed that the inlining pass did some work
     fn trace_access(&self, access: &ast::SymbolAccess) -> Option<TraceAccess> {
+        assert_eq!(
+            self.trace_columns.len(),
+            1,
+            "In MIR, expected exactly one trace segment to be present"
+        );
         let id = access.name.as_ref();
-        if let Some(segment) = self.trace_columns.first() {
-            if segment.name == id {
-                if let AccessType::Index(column) = access.access_type {
-                    return Some(TraceAccess::new(TraceSegmentId::Main, column, access.offset));
-                } else {
-                    // This should have been caught earlier during compilation
-                    unreachable!(
-                        "unexpected trace access type encountered during lowering: {:#?}",
-                        &access
-                    );
-                }
-            }
+        let segment = self.trace_columns.first().unwrap();
 
-            if let Some(binding) = segment.bindings.iter().find(|tb| tb.name.as_ref() == Some(id)) {
-                return match access.access_type {
-                    AccessType::Default if binding.size == 1 => {
-                        Some(TraceAccess::new(binding.segment, binding.offset, access.offset))
-                    },
-                    AccessType::Index(extra_offset) if binding.size > 1 => Some(TraceAccess::new(
-                        binding.segment,
-                        binding.offset + extra_offset,
-                        access.offset,
-                    )),
-                    _ => None,
-                };
+        if segment.name == id {
+            // We access $main[i]
+            if let AccessType::Index(column) = access.access_type {
+                Some(TraceAccess::new(TraceSegmentId::Main, column, access.offset))
+            } else {
+                // This should have been caught earlier during compilation
+                unreachable!(
+                    "unexpected trace access type encountered during lowering: {:#?}",
+                    &access
+                );
             }
+        } else if let Some(binding) =
+            segment.bindings.iter().find(|tb| tb.name.as_ref() == Some(id))
+        {
+            // We access a trace binding defined in the main trace.
+            match access.access_type {
+                AccessType::Default if binding.size == 1 => {
+                    Some(TraceAccess::new(binding.segment, binding.offset, access.offset))
+                },
+                AccessType::Index(extra_offset) if binding.size > 1 => Some(TraceAccess::new(
+                    binding.segment,
+                    binding.offset + extra_offset,
+                    access.offset,
+                )),
+                _ => None,
+            }
+        } else {
+            // We do not access a trace
+            None
         }
-        None
     }
 }
 

--- a/parser/src/ast/trace.rs
+++ b/parser/src/ast/trace.rs
@@ -22,7 +22,7 @@ impl fmt::Display for TraceSegmentId {
 
 impl TraceSegmentId {
     /// Returns the index of this segment
-    pub fn index(&self) -> usize {
+    pub const fn index(&self) -> usize {
         match self {
             TraceSegmentId::Main => 0,
             TraceSegmentId::Aux => 1,

--- a/parser/src/ast/trace.rs
+++ b/parser/src/ast/trace.rs
@@ -5,7 +5,20 @@ use miden_diagnostics::{SourceSpan, Spanned};
 use super::*;
 
 /// The id of a trace segment is its index in the trace_columns declaration
-pub type TraceSegmentId = usize;
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum TraceSegmentId {
+    Main,
+    Aux,
+}
+
+impl fmt::Display for TraceSegmentId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TraceSegmentId::Main => write!(f, "main"),
+            TraceSegmentId::Aux => write!(f, "aux"),
+        }
+    }
+}
 
 /// The index of a column in a particular trace segment
 pub type TraceColumnIndex = usize;

--- a/parser/src/ast/trace.rs
+++ b/parser/src/ast/trace.rs
@@ -20,6 +20,16 @@ impl fmt::Display for TraceSegmentId {
     }
 }
 
+impl TraceSegmentId {
+    /// Returns the index of this segment
+    pub fn index(&self) -> usize {
+        match self {
+            TraceSegmentId::Main => 0,
+            TraceSegmentId::Aux => 1,
+        }
+    }
+}
+
 /// The index of a column in a particular trace segment
 pub type TraceColumnIndex = usize;
 

--- a/parser/src/ast/trace.rs
+++ b/parser/src/ast/trace.rs
@@ -7,8 +7,8 @@ use super::*;
 /// The id of a trace segment is its index in the trace_columns declaration
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TraceSegmentId {
-    Main,
-    Aux,
+    Main = 0,
+    Aux = 1,
 }
 
 impl fmt::Display for TraceSegmentId {

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -114,7 +114,7 @@ MainSegmentId: Identifier = {
 
 MainTraceBindings: TraceSegment = {
     <l:@L> <name:MainSegmentId> ":" <bindings: Vector<TraceBinding>> "," <r:@R> =>
-        TraceSegment::new(span!(l, r), 0, name, bindings),
+        TraceSegment::new(span!(l, r), TraceSegmentId::Main, name, bindings),
 }
 
 TraceBinding: Span<(Identifier, usize)> = {
@@ -195,14 +195,22 @@ EvaluatorFunction: EvaluatorFunction = {
 
 EvaluatorBindings: Vec<TraceSegment> = {
     <l:@L> <trace: Comma<EvaluatorSegmentBindings>> <r:@R> =>? {
-        let mut segments = Vec::with_capacity(trace.len());
+        if trace.len() > 1 {
+            diagnostics.diagnostic(Severity::Error)
+                .with_message("invalid evaluator function definition")
+                .with_primary_label(span!(l, r), "evaluators cannot have more than one trace segment")
+                .emit();
+            return Err(ParseError::Failed.into());
+        }
 
-        for (segment, (span, bindings)) in trace.into_iter().enumerate() {
+        let mut segments = Vec::with_capacity(trace.len());
+        
+        if let Some((span, bindings)) = trace.into_iter().next() {
             // We generate a name for these segments to distinguish them from direct references
             // to the actual main columns. This is useful during the inlining phase
             let segment_name = Identifier::new(span, Symbol::intern(format!("%{}", *next_var)));
             *next_var += 1;
-            segments.push(TraceSegment::new(span, segment, segment_name, bindings));
+            segments.push(TraceSegment::new(span, TraceSegmentId::Main, segment_name, bindings));
         }
 
         // the last segment of trace columns cannot be empty.

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -195,10 +195,10 @@ EvaluatorFunction: EvaluatorFunction = {
 
 EvaluatorBindings: Vec<TraceSegment> = {
     <l:@L> <trace: Comma<EvaluatorSegmentBindings>> <r:@R> =>? {
-        if trace.len() > 1 {
+        if trace.len() != 1 {
             diagnostics.diagnostic(Severity::Error)
                 .with_message("invalid evaluator function definition")
-                .with_primary_label(span!(l, r), "evaluators cannot have more than one trace segment")
+                .with_primary_label(span!(l, r), "evaluators must have exactly one trace segment")
                 .emit();
             return Err(ParseError::Failed.into());
         }

--- a/parser/src/parser/tests/arithmetic_ops.rs
+++ b/parser/src/parser/tests/arithmetic_ops.rs
@@ -22,7 +22,7 @@ fn single_addition() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(add!(access!(clk, 1), access!(clk)), int!(0)))],
         ),
     );
@@ -45,7 +45,7 @@ fn multi_addition() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(add!(add!(access!(clk, 1), access!(clk)), int!(2)), int!(0)))],
         ),
     );
@@ -68,7 +68,7 @@ fn single_subtraction() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(sub!(access!(clk, 1), access!(clk)), int!(0)))],
         ),
     );
@@ -91,7 +91,7 @@ fn multi_subtraction() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(sub!(sub!(access!(clk, 1), access!(clk)), int!(1)), int!(0)))],
         ),
     );
@@ -114,7 +114,7 @@ fn single_multiplication() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(mul!(access!(clk, 1), access!(clk)), int!(0)))],
         ),
     );
@@ -137,7 +137,7 @@ fn multi_multiplication() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(mul!(mul!(access!(clk, 1), access!(clk)), int!(2)), int!(0)))],
         ),
     );
@@ -160,7 +160,7 @@ fn unit_with_parens() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(add!(int!(2), int!(1)), int!(3)))],
         ),
     );
@@ -183,7 +183,7 @@ fn ops_with_parens() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(mul!(add!(access!(clk, 1), access!(clk)), int!(2)), int!(4)))],
         ),
     );
@@ -206,7 +206,7 @@ fn const_exponentiation() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(exp!(access!(clk, 1), int!(2)), int!(1)))],
         ),
     );
@@ -229,7 +229,7 @@ fn non_const_exponentiation() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(exp!(access!(clk, 1), add!(access!(clk), int!(2))), int!(1)))],
         ),
     );
@@ -276,7 +276,7 @@ fn multi_arithmetic_ops_same_precedence() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(
                 add!(sub!(sub!(access!(clk, 1), access!(clk)), int!(2)), int!(1)),
                 int!(0)
@@ -308,7 +308,7 @@ fn multi_arithmetic_ops_different_precedence() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(
                 sub!(sub!(exp!(access!(clk, 1), int!(2)), mul!(access!(clk), int!(2))), int!(1)),
                 int!(0)
@@ -340,7 +340,7 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(
                 sub!(access!(clk, 1), mul!(exp!(access!(clk), int!(2)), sub!(int!(2), int!(1)))),
                 int!(0)

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -53,7 +53,9 @@ integrity_constraints {
 /// This is used as a common base for most tests in this module
 fn test_module() -> Module {
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));

--- a/parser/src/parser/tests/buses.rs
+++ b/parser/src/parser/tests/buses.rs
@@ -15,7 +15,9 @@ public_inputs {
 }"#;
 
 fn add_base_expectations(expected: &mut Module) {
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));

--- a/parser/src/parser/tests/calls.rs
+++ b/parser/src/parser/tests/calls.rs
@@ -23,7 +23,7 @@ fn call_fold_identifier() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(a, 1), (c, 2)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(a, 1), (c, 2)])],
             body,
         ),
     );
@@ -51,7 +51,7 @@ fn call_fold_vector_literal() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(a, 1), (b, 1), (c, 4)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(a, 1), (b, 1), (c, 4)])],
             body,
         ),
     );
@@ -81,7 +81,7 @@ fn call_fold_list_comprehension() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(a, 1), (b, 1), (c, 4)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(a, 1), (b, 1), (c, 4)])],
             body,
         ),
     );

--- a/parser/src/parser/tests/constant_propagation.rs
+++ b/parser/src/parser/tests/constant_propagation.rs
@@ -63,9 +63,11 @@ fn test_constant_propagation() {
     let program = pass.run(program).unwrap();
 
     let mut expected = Program::new(ident!(root));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(clk, 1), (a, 1), (b, 2), (c, 1)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(clk, 1), (a, 1), (b, 2), (c, 1)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 0));
@@ -98,7 +100,7 @@ fn test_constant_propagation() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test_constraint),
-            vec![trace_segment!(0, "%0", [(b0, 1), (b1, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(b0, 1), (b1, 1)])],
             body,
         ),
     );

--- a/parser/src/parser/tests/evaluators.rs
+++ b/parser/src/parser/tests/evaluators.rs
@@ -196,7 +196,7 @@ fn ev_fn_def_with_multiple_args() {
         enf clk' = clk + 1
     }";
     ParseTest::new()
-        .expect_module_diagnostic(source, "evaluators cannot have more than one trace segment");
+        .expect_module_diagnostic(source, "evaluators must have exactly one trace segment");
 }
 
 #[test]

--- a/parser/src/parser/tests/evaluators.rs
+++ b/parser/src/parser/tests/evaluators.rs
@@ -21,7 +21,7 @@ fn ev_fn_main_cols() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(advance_clock),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce!(eq!(access!(clk, 1), add!(access!(clk), int!(1))))],
         ),
     );
@@ -50,7 +50,9 @@ fn ev_fn_call_simple() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -88,9 +90,11 @@ fn ev_fn_call() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 2), (b, 4), (c, 6)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 2), (b, 4), (c, 6)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -126,7 +130,7 @@ fn ev_fn_call_inside_ev_fn() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(ev_func),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             body,
         ),
     );
@@ -156,9 +160,11 @@ fn ev_fn_call_with_more_than_two_args() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 1)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 1)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -182,11 +188,23 @@ fn ev_fn_call_with_more_than_two_args() {
 // ================================================================================================
 
 #[test]
-fn ev_fn_def_with_empty_final_arg() {
+fn ev_fn_def_with_multiple_args() {
     let source = "
     mod test
 
-    ev ev_func([clk], []) {
+    ev ev_func([clk], [a, b]) {
+        enf clk' = clk + 1
+    }";
+    ParseTest::new()
+        .expect_module_diagnostic(source, "evaluators cannot have more than one trace segment");
+}
+
+#[test]
+fn ev_fn_def_with_empty_arg() {
+    let source = "
+    mod test
+
+    ev ev_func([]) {
         enf clk' = clk + 1
     }";
     ParseTest::new().expect_module_diagnostic(source, "the last trace segment cannot be empty");

--- a/parser/src/parser/tests/functions.rs
+++ b/parser/src/parser/tests/functions.rs
@@ -93,7 +93,9 @@ fn fn_use_scalars_and_vectors() {
         ),
     );
 
-    expected.trace_columns.push(trace_segment!(0, "$main", [(a, 1), (b, 12)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 1), (b, 12)]));
 
     expected.public_inputs.insert(
         ident!(stack_inputs),
@@ -167,7 +169,9 @@ fn fn_call_in_fn() {
         ),
     );
 
-    expected.trace_columns.push(trace_segment!(0, "$main", [(a, 1), (b, 12)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 1), (b, 12)]));
 
     expected.public_inputs.insert(
         ident!(stack_inputs),
@@ -252,7 +256,7 @@ fn fn_call_in_ev() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(evaluator),
-            vec![trace_segment!(0, "%0", [(a, 1), (b, 12)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(a, 1), (b, 12)])],
             vec![enforce!(eq!(
                 access!(a, 1),
                 call!(fold_scalar_and_vec(expr!(access!(a)), expr!(access!(b))))
@@ -260,7 +264,9 @@ fn fn_call_in_ev() {
         ),
     );
 
-    expected.trace_columns.push(trace_segment!(0, "$main", [(a, 1), (b, 12)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 1), (b, 12)]));
 
     expected.public_inputs.insert(
         ident!(stack_inputs),
@@ -320,7 +326,9 @@ fn fn_as_lc_iterables() {
         ),
     );
 
-    expected.trace_columns.push(trace_segment!(0, "$main", [(a, 12), (b, 12)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 12), (b, 12)]));
 
     expected.public_inputs.insert(
         ident!(stack_inputs),
@@ -393,7 +401,9 @@ fn fn_call_in_binary_ops() {
         ),
     );
 
-    expected.trace_columns.push(trace_segment!(0, "$main", [(a, 12), (b, 12)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 12), (b, 12)]));
 
     expected.public_inputs.insert(
         ident!(stack_inputs),
@@ -465,7 +475,9 @@ fn fn_call_in_vector_def() {
         ),
     );
 
-    expected.trace_columns.push(trace_segment!(0, "$main", [(a, 12), (b, 12)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 12), (b, 12)]));
 
     expected.public_inputs.insert(
         ident!(stack_inputs),

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -28,7 +28,9 @@ fn integrity_constraints() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -75,7 +77,9 @@ fn integrity_constraints_with_buses() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -177,7 +181,9 @@ fn multiple_integrity_constraints() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -221,7 +227,9 @@ fn integrity_constraint_with_periodic_col() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(b, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(b, 1)]));
     expected
         .periodic_columns
         .insert(ident!(k0), PeriodicColumn::new(SourceSpan::UNKNOWN, ident!(k0), vec![1, 0]));
@@ -265,7 +273,9 @@ fn integrity_constraint_with_constants() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected.constants.insert(ident!(A), constant!(A = 0));
     expected.constants.insert(ident!(B), constant!(B = [0, 1]));
     expected.constants.insert(ident!(C), constant!(C = [[0, 1], [1, 0]]));
@@ -311,7 +321,9 @@ fn integrity_constraint_with_variables() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -351,7 +363,9 @@ fn integrity_constraint_with_indexed_trace_access() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(a, 1), (b, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 1), (b, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -391,9 +405,11 @@ fn ic_comprehension_one_iterable_identifier() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -432,9 +448,11 @@ fn ic_comprehension_one_iterable_range() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -473,9 +491,11 @@ fn ic_comprehension_with_selectors() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(s, 2), (a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(s, 2), (a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -518,15 +538,17 @@ fn ic_comprehension_with_evaluator_call() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4), (d, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4), (d, 4)]
+    ));
     expected.evaluators.insert(
         ident!(is_binary),
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(is_binary),
-            vec![trace_segment!(0, "%0", [(x, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(x, 1)])],
             vec![enforce!(eq!(exp!(access!(x), int!(2)), access!(x)))],
         ),
     );
@@ -573,7 +595,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
     expected.trace_columns.push(trace_segment!(
-        0,
+        TraceSegmentId::Main,
         "$main",
         [(s, 2), (a, 1), (b, 1), (c, 4), (d, 4)]
     ));
@@ -582,7 +604,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(is_binary),
-            vec![trace_segment!(0, "%0", [(x, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(x, 1)])],
             vec![enforce!(eq!(exp!(access!(x), int!(2)), access!(x)))],
         ),
     );
@@ -632,7 +654,7 @@ fn ic_match_constraint() {
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
     expected.trace_columns.push(trace_segment!(
-        0,
+        TraceSegmentId::Main,
         "$main",
         [(s, 2), (a, 1), (b, 1), (c, 4), (d, 4)]
     ));
@@ -641,7 +663,7 @@ fn ic_match_constraint() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(is_binary),
-            vec![trace_segment!(0, "%0", [(x, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(x, 1)])],
             vec![enforce!(eq!(exp!(access!(x), int!(2)), access!(x)))],
         ),
     );

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -31,9 +31,11 @@ fn bc_one_iterable_identifier_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -76,9 +78,11 @@ fn bc_identifier_and_range_lc() {
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
     expected.constants.insert(ident!(THREE), constant!(THREE = 3));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -118,9 +122,11 @@ fn bc_iterable_slice_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -158,9 +164,11 @@ fn bc_two_iterable_identifier_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4), (d, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4), (d, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -200,9 +208,11 @@ fn bc_multiple_iterables_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 3), (c, 4), (d, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 3), (c, 4), (d, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -247,9 +257,11 @@ fn ic_one_iterable_identifier_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -292,9 +304,11 @@ fn ic_iterable_identifier_range_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -336,9 +350,11 @@ fn ic_iterable_slice_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -378,9 +394,11 @@ fn ic_two_iterable_identifier_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 1), (c, 4), (d, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 1), (c, 4), (d, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -422,9 +440,11 @@ fn ic_multiple_iterables_lc() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(a, 1), (b, 3), (c, 4), (d, 4)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(a, 1), (b, 3), (c, 4), (d, 4)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -382,7 +382,7 @@ macro_rules! call {
 }
 
 macro_rules! trace_segment {
-    ($idx:literal, $name:literal, [$(($binding_name:ident, $binding_size:literal)),*]) => {
+    ($idx:expr, $name:literal, [$(($binding_name:ident, $binding_size:literal)),*]) => {
         TraceSegment::new(miden_diagnostics::SourceSpan::UNKNOWN, $idx, ident!($name), vec![
             $(miden_diagnostics::Span::new(miden_diagnostics::SourceSpan::UNKNOWN, (ident!($binding_name), $binding_size))),*
         ])
@@ -689,9 +689,11 @@ fn full_air_file() {
     // trace_columns {
     //     main: [clk, fmp, ctx]
     // }
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(clk, 1), (fmp, 1), (ctx, 1)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(clk, 1), (fmp, 1), (ctx, 1)]
+    ));
     // integrity_constraints {
     //     enf clk' = clk + 1
     // }

--- a/parser/src/parser/tests/modules.rs
+++ b/parser/src/parser/tests/modules.rs
@@ -40,9 +40,11 @@ fn import_declaration() {
 #[test]
 fn modules_integration_test() {
     let mut expected = Program::new(ident!(import_example));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(clk, 1), (fmp, 1), (ctx, 1)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(clk, 1), (fmp, 1), (ctx, 1)]
+    ));
     expected.periodic_columns.insert(
         ident!(foo, k0),
         PeriodicColumn::new(SourceSpan::UNKNOWN, ident!(k0), vec![1, 1, 0, 0]),
@@ -65,7 +67,7 @@ fn modules_integration_test() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(bar_constraint),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce_if!(match_arm!(
                 eq!(
                     access!(clk, 1, Type::Felt),
@@ -83,7 +85,7 @@ fn modules_integration_test() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(foo_constraint),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             vec![enforce_if!(match_arm!(
                 eq!(access!(clk, 1, Type::Felt), add!(access!(clk, Type::Felt), int!(1))),
                 access!(foo, k0, Type::Felt)

--- a/parser/src/parser/tests/pub_inputs.rs
+++ b/parser/src/parser/tests/pub_inputs.rs
@@ -29,7 +29,9 @@ fn public_inputs_vec() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected.public_inputs.insert(
         ident!(program_hash),
         PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(program_hash), 4),
@@ -70,7 +72,9 @@ fn public_inputs_table() {
     }";
 
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
     expected
         .public_inputs
         .insert(ident!(a), PublicInput::new_table(SourceSpan::UNKNOWN, ident!(a), 4));

--- a/parser/src/parser/tests/selectors.rs
+++ b/parser/src/parser/tests/selectors.rs
@@ -27,7 +27,9 @@ fn single_selector() {
         enf clk' = clk when n1;
     }"#;
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected.trace_columns.push(trace_segment!(0, "$main", [(clk, 1), (n1, 1)]));
+    expected
+        .trace_columns
+        .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1), (n1, 1)]));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -63,9 +65,11 @@ fn chained_selectors() {
         enf clk' = clk when (n1 & !n2) | !n3;
     }"#;
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(clk, 1), (n1, 1), (n2, 1), (n3, 1)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(clk, 1), (n1, 1), (n2, 1), (n3, 1)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -27,9 +27,11 @@ fn trace_columns() {
         enf clk = 0;
     }"#;
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(clk, 1), (fmp, 1), (ctx, 1)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(clk, 1), (fmp, 1), (ctx, 1)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));
@@ -64,9 +66,11 @@ fn trace_columns_groups() {
         enf clk' = clk - 1;
     }"#;
     let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
-    expected
-        .trace_columns
-        .push(trace_segment!(0, "$main", [(clk, 1), (fmp, 1), (ctx, 1), (a, 3)]));
+    expected.trace_columns.push(trace_segment!(
+        TraceSegmentId::Main,
+        "$main",
+        [(clk, 1), (fmp, 1), (ctx, 1), (a, 3)]
+    ));
     expected
         .public_inputs
         .insert(ident!(inputs), PublicInput::new_vector(SourceSpan::UNKNOWN, ident!(inputs), 2));

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -25,7 +25,7 @@ fn variables_with_and_operators() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             body,
         ),
     );
@@ -52,7 +52,7 @@ fn variables_with_or_operators() {
         EvaluatorFunction::new(
             SourceSpan::UNKNOWN,
             ident!(test),
-            vec![trace_segment!(0, "%0", [(clk, 1)])],
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(clk, 1)])],
             body,
         ),
     );

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1377,13 +1377,13 @@ impl SemanticAnalysis<'_> {
                                     },
                                     Ok(BindingType::Bus(_)) => {
                                         // Buses are valid in boundary constraints
-                                        (ty, 0)
+                                        (ty, TraceSegmentId::Main)
                                     },
                                     Ok(aty) => {
                                         let expected = BindingType::TraceColumn(TraceBinding::new(
                                             constraint_span,
                                             Identifier::new(constraint_span, symbols::Main),
-                                            0,
+                                            TraceSegmentId::Main,
                                             0,
                                             1,
                                             Type::Felt,
@@ -1912,7 +1912,7 @@ impl SemanticAnalysis<'_> {
 
 fn segment_id_to_name(id: TraceSegmentId) -> Symbol {
     match id {
-        0 => symbols::Main,
+        TraceSegmentId::Main => symbols::Main,
         _ => unimplemented!(),
     }
 }


### PR DESCRIPTION
This PR closes https://github.com/0xMiden/air-script/issues/406.

For now, I've kept only `Main` and `Aux` variants without a way to specify multiple main traces.
It should not cause issues to do it later when https://github.com/0xMiden/air-script/issues/379 is better scoped

There is some awkwardness as we still handle `Vec<TraceSegment>` in many structures where only the main trace would be valid, but I've tried to keep the changes of this PR to a minimum, to be adapted later depending on https://github.com/0xMiden/air-script/issues/379.