### PR TITLE
CI: upgrade rust-toolchain installs in CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/1-bugreport.yml
@@ -1,0 +1,38 @@
+name: "Bug Report"
+description: "File a bug report"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+  - type: textarea
+    id: version
+    attributes:
+      label: "Packages versions"
+      description: "Let us know the versions of any other packages used. For example, which version of AirScript are you using?"
+      placeholder: "air-script: 0.1.0"
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: "Bug description"
+      description: "Describe the behavior you are experiencing."
+      placeholder: "Tell us what happened and what should have happened."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce-steps
+    attributes:
+      label: "How can this be reproduced?"
+      description: "If possible, describe how to replicate the unexpected behavior that you see."
+      placeholder: "Steps!"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This is automatically formatted as code, no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,20 @@
+name: "Feature request"
+description: "Request new goodies"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill a feature request!
+  - type: textarea
+    id: scenario-why
+    attributes:
+      label: "Feature description"
+    validations:
+      required: true
+  - type: textarea
+    id: scenario-how
+    attributes:
+      label: "Why is this feature needed?"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-task.yml
+++ b/.github/ISSUE_TEMPLATE/3-task.yml
@@ -1,0 +1,35 @@
+name: "Task"
+description: "Work item"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A task should be less than a week worth of work!
+  - type: textarea
+    id: task-what
+    attributes:
+      label: "What should be done?"
+      placeholder: "Add support for new constraint type"
+    validations:
+      required: true
+  - type: textarea
+    id: task-how
+    attributes:
+      label: "How should it be done?"
+      placeholder: "Implement the new constraint type in the parser and codegen"
+    validations:
+      required: true
+  - type: textarea
+    id: task-done
+    attributes:
+      label: "When is this task done?"
+      placeholder: "The task is done when the new constraint type is fully implemented and tested"
+    validations:
+      required: true
+  - type: textarea
+    id: task-related
+    attributes:
+      label: "Additional context"
+      description: "Add context to the tasks. E.g. other related tasks or relevant discussions on PRs/chats."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Describe your changes
+
+
+## Checklist before requesting a review
+- Repo forked and branch created from `next` according to naming convention.
+- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
+- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+- Relevant issues are linked in the PR description.
+- Tests added for new functionality.
+- Documentation/comments updated according to changes.
+- Updated `CHANGELOG.md`

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+# Runs changelog related jobs.
+# CI job heavily inspired by: https://github.com/tarides/changelog-check-action
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for changes in changelog
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
+        run: ./scripts/check-changelog.sh
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   test:
     name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
@@ -16,13 +19,24 @@ jobs:
         toolchain: [stable, nightly]
         os: [ubuntu]
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{matrix.toolchain}}
-          override: true
-      - name: Test
-        uses: actions-rs/cargo@v1
+      - name: Run tests
+        run: make test
+
+  check:
+    name: Check
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: test
+          toolchain: stable
+      - name: Run check
+        run: make check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - name: Install nightly rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+          components: rustfmt
       - name: Run clippy
         run: make lint
 
@@ -37,7 +42,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
       - name: Run rustfmt
         run: make format-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,3 @@
-# Runs linting related jobs.
-
 name: lint
 
 # Limits workflow concurrency to only the latest commit in the PR.
@@ -15,17 +13,19 @@ on:
 
 jobs:
   clippy:
-    name: clippy
+    name: Clippy
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - name: Clippy
-        run: |
-          rustup update --no-self-update
-          rustup component add clippy
-          make clippy
+      - uses: actions/checkout@v4
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Run clippy
+        run: make lint
 
   rustfmt:
     name: rustfmt
@@ -33,12 +33,14 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - name: Rustfmt
-        run: |
-          rustup update --no-self-update nightly
-          rustup +nightly component add rustfmt
-          make format-check
+      - uses: actions/checkout@v4
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Run rustfmt
+        run: make format-check
 
   doc:
     name: doc
@@ -46,8 +48,10 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - name: Build docs
-        run: |
-          rustup update --no-self-update
-          make doc
+        run: make doc

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,22 @@ help:
 
 WARNINGS=RUSTDOCFLAGS="-D warnings"
 
+# -- building --------------------------------------------------------------------------------------
+
+.PHONY: build
+build: ## Build the project
+	cargo build --workspace
+
+.PHONY: check
+check: ## Run type checker
+	cargo check --workspace --all-targets
+
+# -- testing --------------------------------------------------------------------------------------
+
+.PHONY: test
+test: ## Run all tests
+	cargo test --workspace
+
 # -- linting --------------------------------------------------------------------------------------
 
 .PHONY: clippy

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ test: ## Run all tests
 
 .PHONY: clippy
 clippy: ## Run Clippy with configs
-	$(WARNINGS) cargo clippy --workspace --all-targets --all-features
+	$(WARNINGS) cargo +stable clippy --workspace --all-targets --all-features
 
 
 .PHONY: fix
 fix: ## Run Fix with configs
-	cargo fix --allow-staged --allow-dirty --all-targets --all-features
+	cargo +stable fix --allow-staged --allow-dirty --all-targets --all-features
 
 
 .PHONY: format

--- a/air/src/ir/mod.rs
+++ b/air/src/ir/mod.rs
@@ -79,7 +79,7 @@ impl Air {
     ///
     /// An empty [Air] is meaningless until it has been populated with
     /// constraints and associated metadata. This is typically done by converting
-    /// an [air_parser::ast::Program] to this struct using the [crate::passes::AstToAir]
+    /// an [air_parser::ast::Program] to this struct using the [crate::passes::MirToAir]
     /// translation pass.
     pub fn new(name: Identifier) -> Self {
         Self {

--- a/codegen/ace/src/layout.rs
+++ b/codegen/ace/src/layout.rs
@@ -41,7 +41,7 @@ pub struct Layout {
     /// Each variable is word-aligned (interleaving with unused variables),
     /// and the region is double-word aligned.
     pub reduced_tables_region: InputRegion,
-    /// Index of a specific reduced table within the [`reduced_tables_region`].
+    /// Index of a specific reduced table within the [`Self::reduced_tables_region`].
     pub reduced_tables: BTreeMap<PublicInputTableAccess, usize>,
     /// Index of the random challenge α used to randomize the multiset/logUp argument
     /// in the *aux* trace.
@@ -281,7 +281,8 @@ pub enum StarkVar {
     /// interpolated.
     GenLast = 3,
     /// The variable `zᵐᵃˣ`, where `max` is equal to `trace_len / max_cycle_len`. Details can be
-    /// found in [`crate::builder::CircuitBuilder::periodic_column`]
+    /// found in `CircuitBuilder::periodic_column`.
+    // TODO: Make this method public or fix the link to the correct location
     ZMaxCycle = 4,
     /// The variable g⁻² corresponding to the penultimate point in the subgroup over which the
     /// trace is interpolated.

--- a/codegen/ace/src/lib.rs
+++ b/codegen/ace/src/lib.rs
@@ -10,15 +10,12 @@ mod tests;
 use air_ir::{Air, ConstraintDomain};
 pub use mir::ir::QuadFelt;
 
-use crate::{
-    builder::{CircuitBuilder, LinearCombination},
-    layout::StarkVar,
-};
+use crate::builder::{CircuitBuilder, LinearCombination};
 pub use crate::{
     circuit::{Circuit as AceCircuit, Node as AceNode},
     encoded::EncodedCircuit as EncodedAceCircuit,
     inputs::{AceVars, AirInputs},
-    layout::Layout as AirLayout,
+    layout::{Layout as AirLayout, StarkVar},
 };
 
 /// Air constraints are organized in 3 main groups: integrity roots,

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -u
+
+CHANGELOG_FILE="${1:-CHANGELOG.md}"
+
+if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
+    # 'no changelog' set, so finish successfully
+    echo "\"no changelog\" label has been set"
+    exit 0
+else
+    # a changelog check is required
+    # fail if the diff is empty
+    if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
+        >&2 echo "Changes should come with an entry in the \"CHANGELOG.md\" file. This behavior
+can be overridden by using the \"no changelog\" label, which is used for changes
+that are trivial / explicitely stated not to require a changelog entry."
+        exit 1
+    fi
+
+    echo "The \"CHANGELOG.md\" file has been updated."
+fi


### PR DESCRIPTION
Migrates to https://github.com/dtolnay/rust-toolchain instead of deprecated actions-rs.

~~Contributes to~~ Closes #394 