### PR TITLE
Refactor trace segment handling to remove `TraceSegmentId::index()` and introduce `TraceShape<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix regressions on MIR and list_comprehensions (#449).
 - Update documentation and tests thereof (#437).
 - Reorder unrolling passes to unroll list comprehensions before match statements (#431).
+- Removed `TraceSegmentId::index()` and replaced segment indexing with `TraceShape<T>`/`FullTraceShape<T>` across ACE codegen, MIR-to-AIR pass, and constraints (#442).
 
 ## 0.4.0 (2025-06-20)
 

--- a/air/src/ir/constraints.rs
+++ b/air/src/ir/constraints.rs
@@ -85,7 +85,7 @@ impl Constraints {
 
     /// Returns the number of boundary constraints applied against the specified trace segment.
     pub fn num_boundary_constraints(&self, trace_segment: TraceSegmentId) -> usize {
-        self.boundary_constraints.get(trace_segment).len()
+        self.boundary_constraints[trace_segment].len()
     }
 
     /// Returns the set of boundary constraints for the given trace segment.
@@ -93,7 +93,7 @@ impl Constraints {
     /// Each boundary constraint is represented by a [ConstraintRoot] which is
     /// the root of the subgraph representing the constraint within the [AlgebraicGraph]
     pub fn boundary_constraints(&self, trace_segment: TraceSegmentId) -> &[ConstraintRoot] {
-        self.boundary_constraints.get(trace_segment).as_slice()
+        self.boundary_constraints[trace_segment].as_slice()
     }
 
     /// Returns a vector of the degrees of the integrity constraints for the specified trace
@@ -102,8 +102,7 @@ impl Constraints {
         &self,
         trace_segment: TraceSegmentId,
     ) -> Vec<IntegrityConstraintDegree> {
-        self.integrity_constraints
-            .get(trace_segment)
+        self.integrity_constraints[trace_segment]
             .iter()
             .map(|entry_index| self.graph.degree(entry_index.node_index()))
             .collect()
@@ -114,7 +113,7 @@ impl Constraints {
     /// Each integrity constraint is represented by a [ConstraintRoot] which is
     /// the root of the subgraph representing the constraint within the [AlgebraicGraph]
     pub fn integrity_constraints(&self, trace_segment: TraceSegmentId) -> &[ConstraintRoot] {
-        self.integrity_constraints.get(trace_segment).as_slice()
+        self.integrity_constraints[trace_segment].as_slice()
     }
 
     /// Inserts a new constraint against `trace_segment`, using the provided `root` and `domain`
@@ -126,9 +125,9 @@ impl Constraints {
     ) {
         let root = ConstraintRoot::new(root, domain);
         if domain.is_boundary() {
-            self.boundary_constraints.get_mut(trace_segment).push(root);
+            self.boundary_constraints[trace_segment].push(root);
         } else {
-            self.integrity_constraints.get_mut(trace_segment).push(root);
+            self.integrity_constraints[trace_segment].push(root);
         }
     }
 

--- a/air/src/ir/constraints.rs
+++ b/air/src/ir/constraints.rs
@@ -28,11 +28,11 @@ pub struct Constraints {
     /// Constraint roots for all boundary constraints against the execution trace, by trace
     /// segment, where boundary constraints are any constraints that apply to either the first
     /// or the last row of the trace.
-    boundary_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
+    boundary_constraints: TraceShape<Vec<ConstraintRoot>>,
     /// Constraint roots for all integrity constraints against the execution trace, by trace
     /// segment, where integrity constraints are any constraints that apply to every row or
     /// every frame.
-    integrity_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
+    integrity_constraints: TraceShape<Vec<ConstraintRoot>>,
     /// A directed acyclic graph which represents all of the constraints and their subexpressions.
     graph: AlgebraicGraph,
 }
@@ -40,8 +40,8 @@ impl Constraints {
     /// Constructs a new [Constraints] graph from the given parts
     pub const fn new(
         graph: AlgebraicGraph,
-        boundary_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
-        integrity_constraints: BTreeMap<TraceSegmentId, Vec<ConstraintRoot>>,
+        boundary_constraints: TraceShape<Vec<ConstraintRoot>>,
+        integrity_constraints: TraceShape<Vec<ConstraintRoot>>,
     ) -> Self {
         Self {
             graph,
@@ -85,7 +85,7 @@ impl Constraints {
 
     /// Returns the number of boundary constraints applied against the specified trace segment.
     pub fn num_boundary_constraints(&self, trace_segment: TraceSegmentId) -> usize {
-        self.boundary_constraints.get(&trace_segment).map_or(0, |v| v.len())
+        self.boundary_constraints.get(trace_segment).len()
     }
 
     /// Returns the set of boundary constraints for the given trace segment.
@@ -93,7 +93,7 @@ impl Constraints {
     /// Each boundary constraint is represented by a [ConstraintRoot] which is
     /// the root of the subgraph representing the constraint within the [AlgebraicGraph]
     pub fn boundary_constraints(&self, trace_segment: TraceSegmentId) -> &[ConstraintRoot] {
-        self.boundary_constraints.get(&trace_segment).map_or(&[], |v| v.as_slice())
+        self.boundary_constraints.get(trace_segment).as_slice()
     }
 
     /// Returns a vector of the degrees of the integrity constraints for the specified trace
@@ -102,11 +102,11 @@ impl Constraints {
         &self,
         trace_segment: TraceSegmentId,
     ) -> Vec<IntegrityConstraintDegree> {
-        self.integrity_constraints.get(&trace_segment).map_or(vec![], |v| {
-            v.iter()
-                .map(|entry_index| self.graph.degree(entry_index.node_index()))
-                .collect()
-        })
+        self.integrity_constraints
+            .get(trace_segment)
+            .iter()
+            .map(|entry_index| self.graph.degree(entry_index.node_index()))
+            .collect()
     }
 
     /// Returns the set of integrity constraints for the given trace segment.
@@ -114,7 +114,7 @@ impl Constraints {
     /// Each integrity constraint is represented by a [ConstraintRoot] which is
     /// the root of the subgraph representing the constraint within the [AlgebraicGraph]
     pub fn integrity_constraints(&self, trace_segment: TraceSegmentId) -> &[ConstraintRoot] {
-        self.integrity_constraints.get(&trace_segment).map_or(&[], |v| v.as_slice())
+        self.integrity_constraints.get(trace_segment).as_slice()
     }
 
     /// Inserts a new constraint against `trace_segment`, using the provided `root` and `domain`
@@ -126,9 +126,9 @@ impl Constraints {
     ) {
         let root = ConstraintRoot::new(root, domain);
         if domain.is_boundary() {
-            self.boundary_constraints.entry(trace_segment).or_default().push(root);
+            self.boundary_constraints.get_mut(trace_segment).push(root);
         } else {
-            self.integrity_constraints.entry(trace_segment).or_default().push(root);
+            self.integrity_constraints.get_mut(trace_segment).push(root);
         }
     }
 

--- a/air/src/ir/mod.rs
+++ b/air/src/ir/mod.rs
@@ -24,6 +24,94 @@ pub use self::{
     value::{PeriodicColumnAccess, PublicInputAccess, Value},
 };
 
+/// A fixed two segment trace shape containing values for the main and aux segments.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct TraceShape<T> {
+    main: T,
+    aux: T,
+}
+
+impl<T> TraceShape<T> {
+    pub fn new(main: T, aux: T) -> Self {
+        Self { main, aux }
+    }
+
+    #[inline]
+    pub fn get(&self, id: TraceSegmentId) -> &T {
+        match id {
+            TraceSegmentId::Main => &self.main,
+            TraceSegmentId::Aux => &self.aux,
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, id: TraceSegmentId) -> &mut T {
+        match id {
+            TraceSegmentId::Main => &mut self.main,
+            TraceSegmentId::Aux => &mut self.aux,
+        }
+    }
+
+    pub fn map<U, F: FnMut(&T) -> U>(&self, mut f: F) -> TraceShape<U> {
+        TraceShape { main: f(&self.main), aux: f(&self.aux) }
+    }
+}
+
+impl<T> core::ops::Index<TraceSegmentId> for TraceShape<T> {
+    type Output = T;
+    fn index(&self, index: TraceSegmentId) -> &Self::Output {
+        self.get(index)
+    }
+}
+
+impl<T> core::ops::IndexMut<TraceSegmentId> for TraceShape<T> {
+    fn index_mut(&mut self, index: TraceSegmentId) -> &mut Self::Output {
+        self.get_mut(index)
+    }
+}
+
+/// A fixed three segment trace shape containing values for the main, aux, and quotient segments.
+///
+/// This wraps a two segment `TraceShape<T>` for the witness traces, and adds a separate
+/// `quotient` segment which is not addressable via `TraceSegmentId`.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct FullTraceShape<T> {
+    pub segments: TraceShape<T>,
+    pub quotient: T,
+}
+
+impl<T> FullTraceShape<T> {
+    pub fn new(main: T, aux: T, quotient: T) -> Self {
+        Self {
+            segments: TraceShape::new(main, aux),
+            quotient,
+        }
+    }
+
+    #[inline]
+    pub fn segments(&self) -> &TraceShape<T> {
+        &self.segments
+    }
+
+    #[inline]
+    pub fn segments_mut(&mut self) -> &mut TraceShape<T> {
+        &mut self.segments
+    }
+}
+
+impl<T> core::ops::Index<TraceSegmentId> for FullTraceShape<T> {
+    type Output = T;
+    fn index(&self, index: TraceSegmentId) -> &Self::Output {
+        &self.segments[index]
+    }
+}
+
+impl<T> core::ops::IndexMut<TraceSegmentId> for FullTraceShape<T> {
+    fn index_mut(&mut self, index: TraceSegmentId) -> &mut Self::Output {
+        &mut self.segments[index]
+    }
+}
+
 /// The offset of the "current" row during constraint evaluation.
 pub const CURRENT_ROW: usize = 0;
 /// The minimum cycle length of a periodic column

--- a/air/src/ir/mod.rs
+++ b/air/src/ir/mod.rs
@@ -41,15 +41,9 @@ impl<T> TraceShape<T> {
     }
 
     /// Returns an iterator over mutable references to `(TraceSegmentId, T)` in segment order.
-    pub fn iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (TraceSegmentId, &mut T)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (TraceSegmentId, &mut T)> {
         let (main, aux) = (&mut self.main, &mut self.aux);
-        [
-            (TraceSegmentId::Main, main),
-            (TraceSegmentId::Aux, aux),
-        ]
-        .into_iter()
+        [(TraceSegmentId::Main, main), (TraceSegmentId::Aux, aux)].into_iter()
     }
 }
 

--- a/air/src/ir/mod.rs
+++ b/air/src/ir/mod.rs
@@ -43,7 +43,7 @@ impl<T> TraceShape<T> {
     /// Returns an iterator over mutable references to `(TraceSegmentId, T)` in segment order.
     pub fn iter_mut(
         &mut self,
-    ) -> core::array::IntoIter<(TraceSegmentId, &mut T), 2> {
+    ) -> impl Iterator<Item = (TraceSegmentId, &mut T)> {
         let (main, aux) = (&mut self.main, &mut self.aux);
         [
             (TraceSegmentId::Main, main),

--- a/air/src/ir/mod.rs
+++ b/air/src/ir/mod.rs
@@ -39,6 +39,18 @@ impl<T> TraceShape<T> {
     pub fn map<U, F: FnMut(&T) -> U>(&self, mut f: F) -> TraceShape<U> {
         TraceShape { main: f(&self.main), aux: f(&self.aux) }
     }
+
+    /// Returns an iterator over mutable references to `(TraceSegmentId, T)` in segment order.
+    pub fn iter_mut(
+        &mut self,
+    ) -> core::array::IntoIter<(TraceSegmentId, &mut T), 2> {
+        let (main, aux) = (&mut self.main, &mut self.aux);
+        [
+            (TraceSegmentId::Main, main),
+            (TraceSegmentId::Aux, aux),
+        ]
+        .into_iter()
+    }
 }
 
 impl<T> core::ops::Index<TraceSegmentId> for TraceShape<T> {

--- a/air/src/ir/mod.rs
+++ b/air/src/ir/mod.rs
@@ -27,29 +27,13 @@ pub use self::{
 /// A fixed two segment trace shape containing values for the main and aux segments.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct TraceShape<T> {
-    main: T,
-    aux: T,
+    pub main: T,
+    pub aux: T,
 }
 
 impl<T> TraceShape<T> {
     pub fn new(main: T, aux: T) -> Self {
         Self { main, aux }
-    }
-
-    #[inline]
-    pub fn get(&self, id: TraceSegmentId) -> &T {
-        match id {
-            TraceSegmentId::Main => &self.main,
-            TraceSegmentId::Aux => &self.aux,
-        }
-    }
-
-    #[inline]
-    pub fn get_mut(&mut self, id: TraceSegmentId) -> &mut T {
-        match id {
-            TraceSegmentId::Main => &mut self.main,
-            TraceSegmentId::Aux => &mut self.aux,
-        }
     }
 
     pub fn map<U, F: FnMut(&T) -> U>(&self, mut f: F) -> TraceShape<U> {
@@ -60,13 +44,40 @@ impl<T> TraceShape<T> {
 impl<T> core::ops::Index<TraceSegmentId> for TraceShape<T> {
     type Output = T;
     fn index(&self, index: TraceSegmentId) -> &Self::Output {
-        self.get(index)
+        match index {
+            TraceSegmentId::Main => &self.main,
+            TraceSegmentId::Aux => &self.aux,
+        }
     }
 }
 
 impl<T> core::ops::IndexMut<TraceSegmentId> for TraceShape<T> {
     fn index_mut(&mut self, index: TraceSegmentId) -> &mut Self::Output {
-        self.get_mut(index)
+        match index {
+            TraceSegmentId::Main => &mut self.main,
+            TraceSegmentId::Aux => &mut self.aux,
+        }
+    }
+}
+
+impl<T> core::ops::Index<usize> for TraceShape<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &Self::Output {
+        match index {
+            0 => &self.main,
+            1 => &self.aux,
+            _ => panic!("invalid segment index"),
+        }
+    }
+}
+
+impl<T> core::ops::IndexMut<usize> for TraceShape<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match index {
+            0 => &mut self.main,
+            1 => &mut self.aux,
+            _ => panic!("invalid segment index"),
+        }
     }
 }
 
@@ -109,6 +120,29 @@ impl<T> core::ops::Index<TraceSegmentId> for FullTraceShape<T> {
 impl<T> core::ops::IndexMut<TraceSegmentId> for FullTraceShape<T> {
     fn index_mut(&mut self, index: TraceSegmentId) -> &mut Self::Output {
         &mut self.segments[index]
+    }
+}
+
+impl<T> core::ops::Index<usize> for FullTraceShape<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &Self::Output {
+        match index {
+            0 => &self.segments.main,
+            1 => &self.segments.aux,
+            2 => &self.quotient,
+            _ => panic!("invalid segment index"),
+        }
+    }
+}
+
+impl<T> core::ops::IndexMut<usize> for FullTraceShape<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match index {
+            0 => &mut self.segments.main,
+            1 => &mut self.segments.aux,
+            2 => &mut self.quotient,
+            _ => panic!("invalid segment index"),
+        }
     }
 }
 

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -51,8 +51,14 @@ impl Pass for MirToAir<'_> {
             main_trace_segment.id
         );
 
-        let mut trace_columns = BTreeMap::new();
-        trace_columns.insert(main_trace_segment.id, main_trace_segment.clone());
+        // Build trace segments shape: always include main; aux may be empty
+        let trace_columns_main = main_trace_segment.clone();
+        let mut trace_columns_aux = TraceSegment::new(
+            SourceSpan::default(),
+            TraceSegmentId::Aux,
+            Identifier::new(SourceSpan::default(), Symbol::intern("$aux")),
+            vec![],
+        );
 
         let mut bus_bindings_map = BTreeMap::new();
         if !buses.is_empty() {
@@ -65,19 +71,21 @@ impl Pass for MirToAir<'_> {
             let aux_trace_segment = TraceSegment::new(
                 SourceSpan::default(),
                 TraceSegmentId::Aux,
-                Identifier::new(
-                    SourceSpan::default(),
-                    Symbol::new(TraceSegmentId::Aux.index() as u32),
-                ),
+                Identifier::new(SourceSpan::default(), Symbol::intern("$aux")),
                 bus_raw_bindings,
             );
             for binding in aux_trace_segment.bindings.iter() {
                 bus_bindings_map.insert(binding.name.unwrap(), binding.offset);
             }
-            trace_columns.insert(aux_trace_segment.id, aux_trace_segment);
+            trace_columns_aux = aux_trace_segment;
         }
 
-        air.trace_segment_widths = trace_columns.values().map(|ts| ts.size as u16).collect();
+        let trace_columns = TraceShape::new(trace_columns_main, trace_columns_aux);
+
+        air.trace_segment_widths = vec![
+            trace_columns[TraceSegmentId::Main].size as u16,
+            trace_columns[TraceSegmentId::Aux].size as u16,
+        ];
         air.num_random_values = mir.num_random_values;
         air.periodic_columns = mir.periodic_columns.clone();
         air.public_inputs = mir.public_inputs.clone();
@@ -118,7 +126,7 @@ impl Pass for MirToAir<'_> {
 struct AirBuilder<'a> {
     diagnostics: &'a DiagnosticsHandler,
     air: &'a mut Air,
-    trace_columns: BTreeMap<TraceSegmentId, TraceSegment>,
+    trace_columns: TraceShape<TraceSegment>,
     bus_bindings_map: BTreeMap<Identifier, usize>,
 }
 
@@ -426,8 +434,8 @@ impl AirBuilder<'_> {
                         // trace segment inference defaults to the lowest segment (the main trace)
                         // and is adjusted according to the use of random
                         // values and trace columns.
-                        let lhs_segment_name = self.trace_columns[&lhs_segment].name;
-                        let rhs_segment_name = self.trace_columns[&rhs_segment].name;
+                        let lhs_segment_name = self.trace_columns[lhs_segment].name;
+                        let rhs_segment_name = self.trace_columns[rhs_segment].name;
                         self.diagnostics.diagnostic(Severity::Error)
                                     .with_message("invalid boundary constraint")
                                     .with_primary_label(lhs_span, format!("this constrains a column in the '{lhs_segment_name}' trace segment"))
@@ -634,12 +642,11 @@ impl AirBuilder<'_> {
         trace_access: MirTraceAccess,
         boundary: &MirBoundary,
     ) -> Result<(), CompileError> {
-        if let Some(prev) = self
-            .trace_columns
-            .get_mut(&trace_access.segment)
-            .expect("Boundary constraint on an unknown trace segment")
-            .mark_constrained(boundary.span(), trace_access.column, boundary.kind)
-        {
+        if let Some(prev) = self.trace_columns.get_mut(trace_access.segment).mark_constrained(
+            boundary.span(),
+            trace_access.column,
+            boundary.kind,
+        ) {
             self.diagnostics
                 .diagnostic(Severity::Error)
                 .with_message("overlapping boundary constraints")

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -642,7 +642,7 @@ impl AirBuilder<'_> {
         trace_access: MirTraceAccess,
         boundary: &MirBoundary,
     ) -> Result<(), CompileError> {
-        if let Some(prev) = self.trace_columns.get_mut(trace_access.segment).mark_constrained(
+        if let Some(prev) = self.trace_columns[trace_access.segment].mark_constrained(
             boundary.span(),
             trace_access.column,
             boundary.kind,

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -53,15 +53,16 @@ impl Pass for MirToAir<'_> {
 
         // Build trace segments shape: always include main; aux may be empty
         let trace_columns_main = main_trace_segment.clone();
-        let mut trace_columns_aux = TraceSegment::new(
-            SourceSpan::default(),
-            TraceSegmentId::Aux,
-            Identifier::new(SourceSpan::default(), Symbol::intern("$aux")),
-            vec![],
-        );
 
         let mut bus_bindings_map = BTreeMap::new();
-        if !buses.is_empty() {
+        let trace_columns_aux = if buses.is_empty() {
+            TraceSegment::new(
+                SourceSpan::default(),
+                TraceSegmentId::Aux,
+                Identifier::new(SourceSpan::default(), Symbol::intern("$aux")),
+                vec![],
+            )
+        } else {
             let bus_raw_bindings: Vec<_> = buses
                 .keys()
                 .map(|k| Span::new(k.span(), (Identifier::new(k.span(), k.name()), 1)))
@@ -77,8 +78,8 @@ impl Pass for MirToAir<'_> {
             for binding in aux_trace_segment.bindings.iter() {
                 bus_bindings_map.insert(binding.name.unwrap(), binding.offset);
             }
-            trace_columns_aux = aux_trace_segment;
-        }
+            aux_trace_segment
+        };
 
         let trace_columns = TraceShape::new(trace_columns_main, trace_columns_aux);
 

--- a/codegen/ace/src/encoded.rs
+++ b/codegen/ace/src/encoded.rs
@@ -206,6 +206,7 @@ impl Circuit {
 mod tests {
     use std::iter::zip;
 
+    use air_ir::FullTraceShape;
     use super::*;
     use crate::{
         circuit::{ArithmeticOp, OperationNode},
@@ -229,22 +230,22 @@ mod tests {
             random_alpha: 0,
             random_beta: 0,
             trace_segments: [
-                [
+                FullTraceShape::new(
                     // Main
                     InputRegion { offset: 0, width: 1 },
                     // Aux
                     InputRegion { offset: 1, width: 0 },
                     // Quotient
-                    InputRegion { offset: 1, width: 0 },
-                ],
-                [
+                    InputRegion { offset: 1, width: 0 }
+                ),
+                FullTraceShape::new(
                     // Main
                     InputRegion { offset: 1, width: 1 },
                     // Aux
                     InputRegion { offset: 2, width: 0 },
                     // Quotient
-                    InputRegion { offset: 2, width: 0 },
-                ],
+                    InputRegion { offset: 2, width: 0 }
+                ),
             ],
             stark_vars: Default::default(),
             num_inputs: 2,

--- a/codegen/ace/src/encoded.rs
+++ b/codegen/ace/src/encoded.rs
@@ -207,6 +207,7 @@ mod tests {
     use std::iter::zip;
 
     use air_ir::FullTraceShape;
+
     use super::*;
     use crate::{
         circuit::{ArithmeticOp, OperationNode},
@@ -236,7 +237,7 @@ mod tests {
                     // Aux
                     InputRegion { offset: 1, width: 0 },
                     // Quotient
-                    InputRegion { offset: 1, width: 0 }
+                    InputRegion { offset: 1, width: 0 },
                 ),
                 FullTraceShape::new(
                     // Main
@@ -244,7 +245,7 @@ mod tests {
                     // Aux
                     InputRegion { offset: 2, width: 0 },
                     // Quotient
-                    InputRegion { offset: 2, width: 0 }
+                    InputRegion { offset: 2, width: 0 },
                 ),
             ],
             stark_vars: Default::default(),

--- a/codegen/ace/src/inputs.rs
+++ b/codegen/ace/src/inputs.rs
@@ -20,16 +20,13 @@ pub struct AirInputs {
     pub public: Vec<Vec<QuadFelt>>,
     /// Reduced public input table values used as boundaries for buses.
     pub reduced_tables: Vec<QuadFelt>,
-    /// Evaluations of the *main* trace.
-    pub main: [Vec<QuadFelt>; 2],
+    /// Evaluations of the segments in the order `main`, `aux`, `quotient`,
+    /// for the current row and next row.
+    pub segments: [FullTraceShape<Vec<QuadFelt>>; 2],
     /// Verifier challenge α used to randomize the multi-set/logUp polynomials in the *aux* trace.
     pub random_alpha: QuadFelt,
     /// Verifier challenge β used to fingerprint bus messages for the *aux* trace.
     pub random_beta: QuadFelt,
-    /// Evaluations of the *aux* trace.
-    pub aux: [Vec<QuadFelt>; 2],
-    /// Evaluations of the *quotient* parts, including in the next row.
-    pub quotient: [Vec<QuadFelt>; 2],
     /// Verifier challenge used to compute the linear combination of constraints.
     pub alpha: QuadFelt,
     /// Verifier challenge corresponding to the point at which the constraint evaluation check is
@@ -53,13 +50,7 @@ impl AirInputs {
     /// the values that would be present in the proof's transcript.
     pub fn into_ace_vars(self, air: &Air) -> AceVars {
         let stark = StarkInputs::new(air, self.log_trace_len, self.alpha, self.z);
-        let [main_curr, main_next] = self.main;
-        let [aux_curr, aux_next] = self.aux;
-        let [quotient_curr, quotient_next] = self.quotient;
-        let segments = [
-            FullTraceShape::new(main_curr, aux_curr, quotient_curr),
-            FullTraceShape::new(main_next, aux_next, quotient_next),
-        ];
+        let segments = self.segments;
         AceVars {
             public: self.public,
             reduced_tables: self.reduced_tables,

--- a/codegen/ace/src/inputs.rs
+++ b/codegen/ace/src/inputs.rs
@@ -1,6 +1,6 @@
 use std::iter::zip;
 
-use air_ir::Air;
+use air_ir::{Air, FullTraceShape};
 use miden_core::Felt;
 use winter_math::{FieldElement, StarkField};
 
@@ -42,7 +42,7 @@ pub struct AirInputs {
 pub struct AceVars {
     pub(crate) public: Vec<Vec<QuadFelt>>,
     pub(crate) reduced_tables: Vec<QuadFelt>,
-    pub(crate) segments: [[Vec<QuadFelt>; 3]; 2],
+    pub(crate) segments: [FullTraceShape<Vec<QuadFelt>>; 2],
     pub(crate) random_alpha: QuadFelt,
     pub(crate) random_beta: QuadFelt,
     pub(crate) stark: StarkInputs,
@@ -56,7 +56,10 @@ impl AirInputs {
         let [main_curr, main_next] = self.main;
         let [aux_curr, aux_next] = self.aux;
         let [quotient_curr, quotient_next] = self.quotient;
-        let segments = [[main_curr, aux_curr, quotient_curr], [main_next, aux_next, quotient_next]];
+        let segments = [
+            FullTraceShape::new(main_curr, aux_curr, quotient_curr),
+            FullTraceShape::new(main_next, aux_next, quotient_next),
+        ];
         AceVars {
             public: self.public,
             reduced_tables: self.reduced_tables,
@@ -164,12 +167,9 @@ impl AceVars {
 
         // Trace values
         for row_offset in [0, 1] {
-            let row_regions = [
-                &layout.trace_segments[row_offset].segments.main,
-                &layout.trace_segments[row_offset].segments.aux,
-                &layout.trace_segments[row_offset].quotient,
-            ];
-            for (segment_row, region) in zip(&self.segments[row_offset], row_regions) {
+            for i in 0..3 {
+                let region = &layout.trace_segments[row_offset][i];
+                let segment_row = &self.segments[row_offset][i];
                 store(&mut mem, region, segment_row.as_slice());
             }
         }

--- a/codegen/ace/src/inputs.rs
+++ b/codegen/ace/src/inputs.rs
@@ -166,7 +166,7 @@ impl AceVars {
         mem[layout.random_beta] = self.random_beta;
 
         // Trace values
-        for row_offset in [0, 1] {
+        for (row_offset, _) in self.segments.iter().enumerate() {
             for i in 0..3 {
                 let region = &layout.trace_segments[row_offset][i];
                 let segment_row = &self.segments[row_offset][i];

--- a/codegen/ace/src/inputs.rs
+++ b/codegen/ace/src/inputs.rs
@@ -164,9 +164,12 @@ impl AceVars {
 
         // Trace values
         for row_offset in [0, 1] {
-            for (segment_row, region) in
-                zip(&self.segments[row_offset], &layout.trace_segments[row_offset])
-            {
+            let row_regions = [
+                &layout.trace_segments[row_offset].segments.main,
+                &layout.trace_segments[row_offset].segments.aux,
+                &layout.trace_segments[row_offset].quotient,
+            ];
+            for (segment_row, region) in zip(&self.segments[row_offset], row_regions) {
                 store(&mut mem, region, segment_row.as_slice());
             }
         }

--- a/codegen/ace/src/layout.rs
+++ b/codegen/ace/src/layout.rs
@@ -208,8 +208,10 @@ impl Layout {
     pub fn trace_access_node(&self, trace_access: &TraceAccess) -> Option<Node> {
         let TraceAccess { segment, column, row_offset } = *trace_access;
         let segments_in_row = self.trace_segments.get(row_offset)?;
-        let segment_index = segment.index();
-        let segment_region = segments_in_row.get(segment_index)?;
+        let segment_region = match segment {
+            air_ir::TraceSegmentId::Main => &segments_in_row[0],
+            air_ir::TraceSegmentId::Aux => &segments_in_row[1],
+        };
         segment_region.as_node(column)
     }
 

--- a/codegen/ace/src/layout.rs
+++ b/codegen/ace/src/layout.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, ops::Range};
 
 use air_ir::{
-    Air, Identifier, PublicInput, PublicInputAccess, PublicInputTableAccess, TraceAccess,
+    Air, FullTraceShape, Identifier, PublicInput, PublicInputAccess, PublicInputTableAccess, TraceAccess,
 };
 
 use crate::circuit::Node;
@@ -69,7 +69,7 @@ pub struct Layout {
     /// # TODO(Issue #391):
     /// The degree of the quotient is fixed to 8 matching the degree of the VM constraints, but
     /// the actual degree can be derived from the [`Air`].
-    pub trace_segments: [[InputRegion; 3]; 2],
+    pub trace_segments: [FullTraceShape<InputRegion>; 2],
     /// Region containing the [`StarkVar`] variables.
     pub stark_vars: InputRegion,
     /// Total number of inputs, padded to the next word-multiple.
@@ -170,7 +170,11 @@ impl Layout {
         // during the FRI query phase.
         // At the moment, we do so by padding each trace with zero-valued columns.
         let trace_segments = [0, 1].map(|_row_offset| {
-            segment_widths.map(|width| allocate_region(offset, width, Alignment::DoubleWord))
+            FullTraceShape::new(
+                allocate_region(offset, segment_widths[0], Alignment::DoubleWord),
+                allocate_region(offset, segment_widths[1], Alignment::DoubleWord),
+                allocate_region(offset, segment_widths[2], Alignment::DoubleWord),
+            )
         });
 
         let stark_vars = allocate_region(offset, StarkVar::num_vars(), Alignment::Word);
@@ -208,10 +212,7 @@ impl Layout {
     pub fn trace_access_node(&self, trace_access: &TraceAccess) -> Option<Node> {
         let TraceAccess { segment, column, row_offset } = *trace_access;
         let segments_in_row = self.trace_segments.get(row_offset)?;
-        let segment_region = match segment {
-            air_ir::TraceSegmentId::Main => &segments_in_row[0],
-            air_ir::TraceSegmentId::Aux => &segments_in_row[1],
-        };
+        let segment_region = &segments_in_row[segment];
         segment_region.as_node(column)
     }
 
@@ -227,7 +228,7 @@ impl Layout {
 
     /// Input nodes associated with the quotient polynomial coefficients.
     pub fn quotient_nodes(&self) -> Vec<Node> {
-        self.trace_segments[0][2].iter_nodes().collect()
+        self.trace_segments[0].quotient.iter_nodes().collect()
     }
 
     /// Input node associated with an auxiliary STARK challenge/variable.

--- a/codegen/ace/src/layout.rs
+++ b/codegen/ace/src/layout.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, ops::Range};
 
 use air_ir::{
-    Air, FullTraceShape, Identifier, PublicInput, PublicInputAccess, PublicInputTableAccess, TraceAccess,
+    Air, FullTraceShape, Identifier, PublicInput, PublicInputAccess, PublicInputTableAccess,
+    TraceAccess,
 };
 
 use crate::circuit::Node;

--- a/codegen/ace/src/tests/quotient.rs
+++ b/codegen/ace/src/tests/quotient.rs
@@ -66,11 +66,7 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
             Operation::Value(v) => match v {
                 Value::Constant(c) => QuadFelt::from(Felt::new(c)),
                 Value::TraceAccess(access) => {
-                    let segment_index = match access.segment {
-                        TraceSegmentId::Main => 0,
-                        TraceSegmentId::Aux => 1,
-                    };
-                    ace_vars.segments[access.row_offset][segment_index][access.column]
+                    ace_vars.segments[access.row_offset][access.segment][access.column]
                 },
                 Value::PeriodicColumn(access) => periodic[&access.name],
                 Value::PublicInput(access) => {

--- a/codegen/ace/src/tests/quotient.rs
+++ b/codegen/ace/src/tests/quotient.rs
@@ -66,7 +66,10 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
             Operation::Value(v) => match v {
                 Value::Constant(c) => QuadFelt::from(Felt::new(c)),
                 Value::TraceAccess(access) => {
-                    let segment_index = access.segment.index();
+                    let segment_index = match access.segment {
+                        TraceSegmentId::Main => 0,
+                        TraceSegmentId::Aux => 1,
+                    };
                     ace_vars.segments[access.row_offset][segment_index][access.column]
                 },
                 Value::PeriodicColumn(access) => periodic[&access.name],

--- a/codegen/ace/src/tests/random.rs
+++ b/codegen/ace/src/tests/random.rs
@@ -1,4 +1,4 @@
-use air_ir::Air;
+use air_ir::{Air, FullTraceShape};
 use rand::Rng;
 use winter_utils::Randomizable;
 
@@ -24,11 +24,11 @@ impl AceVars {
         let reduced_tables = layout.reduced_tables_region.random();
         let segments = layout
             .trace_segments
-            .map(|segment_row| [
+            .map(|segment_row| FullTraceShape::new(
                 segment_row.segments.main.random(),
                 segment_row.segments.aux.random(),
                 segment_row.quotient.random(),
-            ]);
+            ));
         let stark = StarkInputs::random(air, log_trace_len);
         Self {
             public,

--- a/codegen/ace/src/tests/random.rs
+++ b/codegen/ace/src/tests/random.rs
@@ -24,7 +24,11 @@ impl AceVars {
         let reduced_tables = layout.reduced_tables_region.random();
         let segments = layout
             .trace_segments
-            .map(|segment_row| segment_row.map(|row_region| row_region.random()));
+            .map(|segment_row| [
+                segment_row.segments.main.random(),
+                segment_row.segments.aux.random(),
+                segment_row.quotient.random(),
+            ]);
         let stark = StarkInputs::random(air, log_trace_len);
         Self {
             public,

--- a/codegen/ace/src/tests/random.rs
+++ b/codegen/ace/src/tests/random.rs
@@ -22,13 +22,13 @@ impl AceVars {
         let layout = Layout::new(air);
         let public = layout.public_inputs.values().map(|pi| pi.random()).collect();
         let reduced_tables = layout.reduced_tables_region.random();
-        let segments = layout
-            .trace_segments
-            .map(|segment_row| FullTraceShape::new(
+        let segments = layout.trace_segments.map(|segment_row| {
+            FullTraceShape::new(
                 segment_row.segments.main.random(),
                 segment_row.segments.aux.random(),
                 segment_row.quotient.random(),
-            ));
+            )
+        });
         let stark = StarkInputs::random(air, log_trace_len);
         Self {
             public,

--- a/parser/src/ast/trace.rs
+++ b/parser/src/ast/trace.rs
@@ -20,16 +20,6 @@ impl fmt::Display for TraceSegmentId {
     }
 }
 
-impl TraceSegmentId {
-    /// Returns the index of this segment
-    pub const fn index(&self) -> usize {
-        match self {
-            TraceSegmentId::Main => 0,
-            TraceSegmentId::Aux => 1,
-        }
-    }
-}
-
 /// The index of a column in a particular trace segment
 pub type TraceColumnIndex = usize;
 

--- a/parser/src/ast/trace.rs
+++ b/parser/src/ast/trace.rs
@@ -20,6 +20,12 @@ impl fmt::Display for TraceSegmentId {
     }
 }
 
+impl From<TraceSegmentId> for usize {
+    fn from(value: TraceSegmentId) -> Self {
+        value as usize
+    }
+}
+
 /// The index of a column in a particular trace segment
 pub type TraceColumnIndex = usize;
 


### PR DESCRIPTION
Closes #442 

This PR addresses the issue raised in #438 by removing the `TraceSegmentId::index()` method and introducing a type safe approach to handling trace segments across the codebase. The goal is to eliminate the reliance on numeric indices for referencing trace segments (main, aux, and quotient) and unify the representation of trace data using the proposed TraceShape<T> and FullTraceShape<T> structs, as suggested by @adr1anh and @bobbinth.

@adr1anh @bobbinth , I would appreciate your feedback on whether the `TraceShape<T>` and `FullTraceShape<T>` implementations fully cover all use cases in the AIR and ACE modules.