### PR TITLE
ci: fix doc build lookup location

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # We specify multiple [output] sections in our book.toml which causes mdbook to create separate folders for each. This moves the generated `html` into its own `html` subdirectory.
-          path: ./docs/book/html
+          path: ./docs/target/book/html
 
   # Deployment job only runs on push to next.
   deploy:


### PR DESCRIPTION
See https://github.com/0xMiden/air-script/actions/runs/17783804137/job/50547572770

The workflow was trying to upload ./docs/book/html but the actual HTML files are generated in `./docs/target/book/html` as configured in `book.toml` (parameter `build-dir` updated in https://github.com/0xMiden/air-script/pull/451).