### PR TITLE
fix: Make docs_sync() test work on windows

### DIFF
--- a/air-script/tests/docs_sync.rs
+++ b/air-script/tests/docs_sync.rs
@@ -3,7 +3,10 @@ use std::{path::Path, process::Command};
 #[test]
 fn docs_sync() {
     let examples_dir = Path::new("../docs/examples");
-    let airc_path = Path::new("target/release/airc");
+    // Use CARGO_MANIFEST_DIR to build an absolute path to airc, needed on Windows to correctly use
+    // `current_dir`.
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let airc_path = Path::new(&manifest_dir).join("../target/release/airc");
 
     // Build the CLI tool first
     let build_output = Command::new("cargo")
@@ -38,11 +41,11 @@ fn docs_sync() {
         let file_name = air_file.file_name().unwrap().to_string_lossy();
         let output_path = air_file.with_extension("rs");
 
-        let output = Command::new(airc_path)
+        let output = Command::new(&airc_path)
             .args(["transpile", air_file.to_str().unwrap(), "-o", output_path.to_str().unwrap()])
             .current_dir("../")
             .output()
-            .unwrap_or_else(|_| panic!("Failed to transpile {}", file_name));
+            .unwrap_or_else(|_| panic!("Failed to transpile {file_name}"));
 
         assert!(
             output.status.success(),
@@ -51,7 +54,7 @@ fn docs_sync() {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        println!("Successfully transpiled: {}", file_name);
+        println!("Successfully transpiled: {file_name}");
 
         // Clean up generated Rust files
         let _ = std::fs::remove_file(output_path);


### PR DESCRIPTION
## Describe your changes

When developing https://github.com/0xMiden/air-script/pull/461, I've noticed that the `docs_sync()` test introduced in https://github.com/0xMiden/air-script/pull/451 did not work on windows. Making the airc program path absolute resolves the issue.