### PR TITLE
chore: propagate code generation errors instead of panicking

### DIFF
--- a/air-script/src/cli/transpile.rs
+++ b/air-script/src/cli/transpile.rs
@@ -66,7 +66,8 @@ impl Transpile {
                         path
                     },
                 };
-                let code = backend.generate(&air).expect("code generation failed");
+                let code =
+                    backend.generate(&air).map_err(|e| format!("code generation failed: {e}"))?;
                 if let Err(err) = fs::write(&output_path, code) {
                     return Err(format!("{err:?}"));
                 }


### PR DESCRIPTION
Replace expect-based panic in CLI code generation with proper Result propagation using map_err and ?. This aligns CLI error handling with parsing/compilation stages, prevents abrupt process termination, and surfaces actionable error messages to users.