### PR TITLE
docs: Fix typos

### DIFF
--- a/air-script/tests/functions/functions_simple.air
+++ b/air-script/tests/functions/functions_simple.air
@@ -47,7 +47,7 @@ boundary_constraints {
 integrity_constraints {
     # -------- function call is assigned to a variable and used in a binary expression ------------
 
-    # binary expression invloving scalar expressions
+    # binary expression involving scalar expressions
     let simple_expression = t * v;
     enf simple_expression = 1;
 

--- a/air-script/tests/functions/inlined_functions_simple.air
+++ b/air-script/tests/functions/inlined_functions_simple.air
@@ -17,7 +17,7 @@ boundary_constraints {
 integrity_constraints {
     # -------- function call is assigned to a variable and used in a binary expression ------------
 
-    # binary expression invloving scalar expressions
+    # binary expression involving scalar expressions
     let simple_expression = t * v;
     enf simple_expression = 1;
 

--- a/mir/src/passes/unrolling/unrolling_first_pass.rs
+++ b/mir/src/passes/unrolling/unrolling_first_pass.rs
@@ -332,13 +332,13 @@ pub fn visit_accessor_bis(accessor: Link<Op>) -> Result<Option<Link<Op>>, Compil
 /// Note that semantic analysis should have already checked they are valid.
 fn validate_iterators_and_get_expected_len(iterators: &[Link<Op>]) -> usize {
     if iterators.is_empty() {
-        unreachable!("Semantic analysis should have catched empty iterators");
+        unreachable!("Semantic analysis should have caught empty iterators");
     }
     let iterator_expected_len = compute_iterator_len(iterators[0].clone());
     for iterator in iterators.iter().skip(1) {
         let iterator_len = compute_iterator_len(iterator.clone());
         if iterator_len != iterator_expected_len {
-            unreachable!("Semantic analysis should have catched iterator length mismatch");
+            unreachable!("Semantic analysis should have caught iterator length mismatch");
         }
     }
     iterator_expected_len


### PR DESCRIPTION
## Describtion

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `invloving` → `involving`
  - `catched` → `caught`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.

