### PR TITLE
Enforce errors for missing items in Import::Partial

### DIFF
--- a/parser/src/sema/import_resolver.rs
+++ b/parser/src/sema/import_resolver.rs
@@ -70,14 +70,16 @@ impl VisitMut<SemanticAnalysisError> for ImportResolver<'_> {
                         Ok(value) => value,
                         Err(err) => return ControlFlow::Break(err),
                     };
-                    for export in imported_from.exports() {
-                        let name = export.name();
-                        // We fetch the item from the set, rather than simply
-                        // check for containment, because we want the span associated
-                        // with the item in the set, not the span associated with the
-                        // export.
-                        if let Some(item) = items.get(&name) {
-                            self.import(module, *from, *item, export)?;
+                    for item in items.iter() {
+                        match imported_from.get(item) {
+                            Some(export) => {
+                                self.import(module, *from, *item, export)?;
+                            },
+                            None => {
+                                return ControlFlow::Break(SemanticAnalysisError::ImportUndefined(
+                                    *from,
+                                ));
+                            },
                         }
                     }
                 },


### PR DESCRIPTION
- Switched partial import resolution to iterate requested items and resolve each via Module::get(&Identifier).
- If an item is not exported by the source module, return ImportUndefined(from) instead of silently ignoring it.
- This prevents no-op imports, aligns behavior with the ImportUndefined error semantics and user expectations for explicit imports, and improves diagnostics by surfacing incorrect use statements early.