### PR TITLE
feat(parser): fix selector check to use Span<u64>.item instead of deref

### DIFF
--- a/parser/src/transforms/constant_propagation.rs
+++ b/parser/src/transforms/constant_propagation.rs
@@ -573,7 +573,7 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                             ScalarExpr::Const(selected) => {
                                 // If the selector returns false on this iteration, go to the next
                                 // step
-                                if *selected == 0 {
+                                if selected.item == 0 {
                                     continue;
                                 }
                             },


### PR DESCRIPTION
The selector in list comprehensions is ScalarExpr::Const(Span<u64>). Dereferencing Span<u64> (*selected == 0) is incorrect and inconsistent with the rest of the codebase, where Span<T> values are accessed via .item. This change uses selected.item == 0, ensuring correct semantics.