### PR TITLE
ci: add rust-toolchain.toml + script to check MSRV

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Clippy
         run: |
           rustup update --no-self-update
-          rustup component add clippy
+          rustup component add --toolchain stable clippy
           make clippy
 
   rustfmt:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,34 @@
+name: Check MSRV
+
+on:
+  push:
+    branches: [next]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+# Limits workflow concurrency to only the latest commit in the PR.
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Check MSRV (aka `rust-version`) in `Cargo.toml` is valid for workspace members
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Cache rustup toolchains
+        run: rustup update
+      - name: Check MSRV for each workspace member
+        run: |
+          chmod +x scripts/check-msrv.sh
+          ./scripts/check-msrv.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["miden contributors"]
 license = "MIT"
 repository = "https://github.com/0xMiden/air-script"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.90"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.90"
+components = ["rustfmt", "rust-src", "clippy"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"

--- a/scripts/check-msrv.sh
+++ b/scripts/check-msrv.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Enhanced MSRV checking script for workspace repository
+# Checks MSRV for each workspace member and provides helpful error messages
+
+# ---- utilities --------------------------------------------------------------
+
+check_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: Required command '$1' is not installed or not in PATH"
+    exit 1
+  fi
+}
+
+# Check required commands
+check_command "cargo"
+check_command "jq"
+check_command "rustup"
+check_command "sed"
+check_command "grep"
+check_command "awk"
+
+# Portable in-place sed (GNU/macOS); usage: sed_i 's/foo/bar/' file
+# shellcheck disable=SC2329  # used quoted
+sed_i() {
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
+# ---- repo root --------------------------------------------------------------
+
+# Get the directory where this script is located and change to the parent directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR/.."
+
+echo "Checking MSRV for workspace members..."
+
+# ---- metadata --------------------------------------------------------------
+
+metadata_json="$(cargo metadata --no-deps --format-version 1)"
+workspace_root="$(printf '%s' "$metadata_json" | jq -r '.workspace_root')"
+
+failed_packages=""
+
+# Iterate actual workspace packages with manifest paths and (maybe) rust_version
+# Fields per line (TSV): id  name  manifest_path  rust_version_or_empty
+while IFS=$'\t' read -r pkg_id package_name manifest_path rust_version; do
+  # Derive package directory (avoid external dirname for portability)
+  package_dir="${manifest_path%/*}"
+  if [[ -z "$package_dir" || "$package_dir" == "$manifest_path" ]]; then
+    package_dir="."
+  fi
+
+  echo "Checking $package_name ($pkg_id) in $package_dir"
+
+  if [[ ! -f "$package_dir/Cargo.toml" ]]; then
+    echo "WARNING: No Cargo.toml found in $package_dir, skipping..."
+    continue
+  fi
+
+  # Prefer cargo metadata's effective rust_version if present
+  current_msrv="$rust_version"
+  if [[ -z "$current_msrv" ]]; then
+    # If the crate inherits: rust-version.workspace = true
+    if grep -Eq '^\s*rust-version\.workspace\s*=\s*true\b' "$package_dir/Cargo.toml"; then
+      # Read from workspace root [workspace.package]
+      current_msrv="$(grep -Eo '^\s*rust-version\s*=\s*"[^"]+"' "$workspace_root/Cargo.toml" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
+      if [[ -n "$current_msrv" ]]; then
+        echo "   Using workspace MSRV: $current_msrv"
+      fi
+    fi
+  fi
+
+  if [[ -z "$current_msrv" ]]; then
+    echo "WARNING: No rust-version found (package or workspace) for $package_name"
+    continue
+  fi
+
+  echo "   Current MSRV: $current_msrv"
+
+  # Try to verify the MSRV
+  if ! cargo msrv verify --manifest-path "$package_dir/Cargo.toml" >/dev/null 2>&1; then
+    echo "ERROR: MSRV check failed for $package_name"
+    failed_packages="$failed_packages $package_name"
+
+    echo "Searching for correct MSRV for $package_name..."
+
+    # Determine the currently-installed stable toolchain version (e.g., "1.81.0")
+    latest_stable="$(rustup run stable rustc --version 2>/dev/null | awk '{print $2}')"
+    if [[ -z "$latest_stable" ]]; then latest_stable="1.81.0"; fi
+
+    # Search for the actual MSRV starting from the current one
+    if actual_msrv=$(cargo msrv find \
+          --manifest-path "$package_dir/Cargo.toml" \
+          --min "$current_msrv" \
+          --max "$latest_stable" \
+          --output-format minimal 2>/dev/null); then
+      echo "   Found actual MSRV: $actual_msrv"
+      echo ""
+      echo "ERROR SUMMARY for $package_name:"
+      echo "   Package:   $package_name"
+      echo "   Directory: $package_dir"
+      echo "   Current (incorrect) MSRV: $current_msrv"
+      echo "   Correct MSRV:             $actual_msrv"
+      echo ""
+      echo "TO FIX:"
+      echo "   Update rust-version in $package_dir/Cargo.toml from \"$current_msrv\" to \"$actual_msrv\""
+      echo ""
+      echo "   Or run this command (portable in-place edit):"
+      echo "     sed_i 's/^\\s*rust-version\\s*=\\s*\"$current_msrv\"/rust-version = \"$actual_msrv\"/' \"$package_dir/Cargo.toml\""
+    else
+      echo "   Could not determine correct MSRV automatically"
+      echo ""
+      echo "ERROR SUMMARY for $package_name:"
+      echo "   Package:   $package_name"
+      echo "   Directory: $package_dir"
+      echo "   Current (incorrect) MSRV: $current_msrv"
+      echo "   Could not automatically determine correct MSRV"
+      echo ""
+      echo "TO FIX:"
+      echo "   Run manually: cargo msrv find --manifest-path \"$package_dir/Cargo.toml\""
+    fi
+    echo "-------------------------------------------------------------------------------"
+  else
+    echo "OK: MSRV check passed for $package_name"
+  fi
+  echo ""
+
+done < <(
+  printf '%s' "$metadata_json" \
+  | jq -r '. as $m
+           | $m.workspace_members[]
+           | . as $id
+           | ($m.packages[] | select(.id == $id)
+              | [ .id, .name, .manifest_path, (.rust_version // "") ] | @tsv)'
+)
+
+if [[ -n "$failed_packages" ]]; then
+  echo "MSRV CHECK FAILED"
+  echo ""
+  echo "The following packages have incorrect MSRV settings:$failed_packages"
+  echo ""
+  echo "Please fix the rust-version fields in the affected Cargo.toml files as shown above."
+  exit 1
+else
+  echo "ALL WORKSPACE MEMBERS PASSED MSRV CHECKS!"
+  exit 0
+fi


### PR DESCRIPTION
This is essentially a port of https://github.com/0xMiden/crypto/pull/547 on this repo. 

Copying the PR description from there.

----
This adds a CI job (locally runnable) that will check the MSRV of a PR is set correctly on a crate-by-crate basis. If the MSRV is set incorrectly, due to e.g. some feature being used, it will compute the correct MSRV for that crate and indicate it in its error. 

The script's error message can be emulated by manually changing the MSRV to an incorrect version (e.g. "1.87") and running it (`./scripts/check-msrv.sh`).
<details><summary> Sample output (click to unfold) </summary>

```
Checking MSRV for workspace members...
Checking miden-crypto in /Users/huitseeker/tmp/crypto/miden-crypto
   Current MSRV: 1.87
ERROR: MSRV check failed for miden-crypto
Searching for correct MSRV for miden-crypto...
   Found actual MSRV: 1.88.0

ERROR SUMMARY for miden-crypto:
   Package:   miden-crypto
   Directory: /Users/huitseeker/tmp/crypto/miden-crypto
   Current (incorrect) MSRV: 1.87
   Correct MSRV:             1.88.0

TO FIX:
   Update rust-version in /Users/huitseeker/tmp/crypto/miden-crypto/Cargo.
toml from "1.87" to "1.88.0"

   Or run this command (portable in-place edit):
     sed_i 's/^\s*rust-version\s*=\s*"1.87"/rust-version = "1.88.0"/' "/Us
ers/huitseeker/tmp/crypto/miden-crypto/Cargo.toml"
--------------------------------------------------------------------------
-----
```
</details>


This further adds a rust-toolchain file that will make CI tooling (and local rustup dev envs) follow the latest stable as it updates.

As a consequence, the following behaviors can change from being proactive to being on-demand:
- bumping the MSRV.

As a side effect, we can expect the MSRV setting to (over time) accurately reflect what we can compile with. Right now, the project or any of its dependents cannot be compiled with Rust 1.88 (and there is not technical reason to impose this restriction).

----

TL;DR:
- the file that drives toolchain bumps is `rust-toolchain.toml`, not the MSRV,
- when using a feature that requires a higher MSRV the script (in CI or locally) helps figure out the adjustment necessary to optimally set the MSRV.