### PR TITLE
Remove codgen trait from mir

### DIFF
--- a/mir/src/codegen.rs
+++ b/mir/src/codegen.rs
@@ -1,8 +1,0 @@
-/// This trait should be implemented on types which handle generating code from AirScript MIR
-pub trait CodeGenerator {
-    /// The type of the artifact produced by this codegen backend
-    type Output;
-
-    /// Generates code using this generator, consuming it in the process
-    fn generate(&self, ir: &crate::ir::Mir) -> anyhow::Result<Self::Output>;
-}

--- a/mir/src/lib.rs
+++ b/mir/src/lib.rs
@@ -1,5 +1,3 @@
-mod codegen;
-
 pub mod ir;
 pub mod passes;
 #[cfg(test)]
@@ -9,7 +7,6 @@ use air_parser::ast::Program;
 use air_pass::Pass;
 use miden_diagnostics::{Diagnostic, DiagnosticsHandler, ToDiagnostic};
 
-pub use self::codegen::CodeGenerator;
 use crate::ir::Mir;
 
 /// Abstracts the various passes done on the MIR representation of the program.


### PR DESCRIPTION
This small PR removes codgen trait from the MIR crate. As far as I can tell, it was not used by anything and I'm not sure what the intention for it was. If there was a reason for it, I'm happy to drop this PR.