### PR TITLE
test: remove boilerplate in tests with test macro

### DIFF
--- a/air-script/tests/binary/test_air.rs
+++ b/air-script/tests/binary/test_air.rs
@@ -3,7 +3,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
-    binary::binary::{BinaryAir, PublicInputs},
+    binary::binary::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -38,17 +39,4 @@ impl AirTester for BinaryAirTester {
     }
 }
 
-#[test]
-fn test_binary_air() {
-    let air_tester = Box::new(BinaryAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = BinaryAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<BinaryAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(test_binary_air, crate::binary::binary::BinaryAir, BinaryAirTester, 1024);

--- a/air-script/tests/bitwise/test_air.rs
+++ b/air-script/tests/bitwise/test_air.rs
@@ -5,7 +5,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{AuxTraceWithMetadata, Trace, TraceTable, matrix::ColMatrix};
 
 use crate::{
-    bitwise::bitwise::{BitwiseAir, PublicInputs},
+    bitwise::bitwise::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -49,17 +50,4 @@ impl AirTester for BitwiseAirTester {
     }
 }
 
-#[test]
-fn test_bitwise_air() {
-    let air_tester = Box::new(BitwiseAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = BitwiseAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<BitwiseAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(test_bitwise_air, crate::bitwise::bitwise::BitwiseAir, BitwiseAirTester, 1024);

--- a/air-script/tests/buses/test_air.rs
+++ b/air-script/tests/buses/test_air.rs
@@ -3,7 +3,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{AuxTraceWithMetadata, Trace, TraceTable, matrix::ColMatrix};
 
 use crate::{
-    buses::buses_complex::{BusesAir, PublicInputs},
+    buses::buses_complex::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -56,17 +57,4 @@ impl AirTester for BusesAirTester {
     }
 }
 
-#[test]
-fn test_buses_air() {
-    let air_tester = Box::new(BusesAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = BusesAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<BusesAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(test_buses_air, crate::buses::buses_complex::BusesAir, BusesAirTester, 1024);

--- a/air-script/tests/constant_in_range/test_air.rs
+++ b/air-script/tests/constant_in_range/test_air.rs
@@ -3,7 +3,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
-    constant_in_range::constant_in_range::{ConstantInRangeAir, PublicInputs},
+    constant_in_range::constant_in_range::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -45,17 +46,9 @@ impl AirTester for ConstantInRangeAirTester {
     }
 }
 
-#[test]
-fn test_constant_in_range_air() {
-    let air_tester = Box::new(ConstantInRangeAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = ConstantInRangeAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<ConstantInRangeAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_constant_in_range_air,
+    crate::constant_in_range::constant_in_range::ConstantInRangeAir,
+    ConstantInRangeAirTester,
+    1024
+);

--- a/air-script/tests/constants/test_air.rs
+++ b/air-script/tests/constants/test_air.rs
@@ -3,7 +3,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
-    constants::constants::{ConstantsAir, PublicInputs},
+    constants::constants::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -43,17 +44,9 @@ impl AirTester for ConstantsAirTester {
     }
 }
 
-#[test]
-fn test_constants_air() {
-    let air_tester = Box::new(ConstantsAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = ConstantsAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<ConstantsAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_constants_air,
+    crate::constants::constants::ConstantsAir,
+    ConstantsAirTester,
+    1024
+);

--- a/air-script/tests/constraint_comprehension/test_air.rs
+++ b/air-script/tests/constraint_comprehension/test_air.rs
@@ -3,9 +3,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
-    constraint_comprehension::constraint_comprehension::{
-        ConstraintComprehensionAir, PublicInputs,
-    },
+    constraint_comprehension::constraint_comprehension::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -49,17 +48,9 @@ impl AirTester for ConstraintComprehensionAirTester {
     }
 }
 
-#[test]
-fn test_constraint_comprehension_air() {
-    let air_tester = Box::new(ConstraintComprehensionAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = ConstraintComprehensionAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<ConstraintComprehensionAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_constraint_comprehension_air,
+    crate::constraint_comprehension::constraint_comprehension::ConstraintComprehensionAir,
+    ConstraintComprehensionAirTester,
+    1024
+);

--- a/air-script/tests/evaluators/test_air.rs
+++ b/air-script/tests/evaluators/test_air.rs
@@ -3,7 +3,8 @@ use winter_math::{FieldElement, fields::f64::BaseElement as Felt};
 use winterfell::{Trace, TraceTable};
 
 use crate::{
-    evaluators::evaluators::{EvaluatorsAir, PublicInputs},
+    evaluators::evaluators::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -40,17 +41,9 @@ impl AirTester for EvaluatorsAirTester {
     }
 }
 
-#[test]
-fn test_evaluators_air() {
-    let air_tester = Box::new(EvaluatorsAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = EvaluatorsAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<EvaluatorsAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_evaluators_air,
+    crate::evaluators::evaluators::EvaluatorsAir,
+    EvaluatorsAirTester,
+    1024
+);

--- a/air-script/tests/fibonacci/test_air.rs
+++ b/air-script/tests/fibonacci/test_air.rs
@@ -5,7 +5,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{AuxTraceWithMetadata, Trace, TraceTable, matrix::ColMatrix};
 
 use crate::{
-    fibonacci::fibonacci::{FibonacciAir, PublicInputs},
+    fibonacci::fibonacci::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -44,17 +45,9 @@ impl AirTester for FibonacciAirTester {
     }
 }
 
-#[test]
-fn test_fibonacci_air() {
-    let air_tester = Box::new(FibonacciAirTester {});
-    let length = 32;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = FibonacciAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<FibonacciAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_fibonacci_air,
+    crate::fibonacci::fibonacci::FibonacciAir,
+    FibonacciAirTester,
+    32
+);

--- a/air-script/tests/functions/test_air.rs
+++ b/air-script/tests/functions/test_air.rs
@@ -3,7 +3,8 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
-    functions::functions_complex::{FunctionsAir, PublicInputs},
+    functions::functions_complex::PublicInputs,
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
 };
 
@@ -67,17 +68,9 @@ impl AirTester for FunctionsAirTester {
     }
 }
 
-#[test]
-fn test_functions_complex_air() {
-    let air_tester = Box::new(FunctionsAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = FunctionsAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<FunctionsAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_functions_complex_air,
+    crate::functions::functions_complex::FunctionsAir,
+    FunctionsAirTester,
+    1024
+);

--- a/air-script/tests/helpers/macros.rs
+++ b/air-script/tests/helpers/macros.rs
@@ -1,0 +1,29 @@
+// Helper macros for test generation
+
+/// Generates an AIR test function with the standard boilerplate
+///
+/// # Arguments
+/// * `test_name` - The identifier for the test function (e.g., `test_binary_air`)
+/// * `air_name` - The identifier for the AIR struct (e.g., `BinaryAir`)
+/// * `tester_name` - The identifier for the `AirTester` struct (e.g., `BinaryAirTester`)
+/// * `trace_length` - The length of the trace for the test (e.g., `32` or `1024`)
+#[macro_export]
+macro_rules! generate_air_test {
+    ($test_name:ident, $air_name:path, $tester_name:ident, $trace_length:expr) => {
+        #[test]
+        fn $test_name() {
+            use winter_math::fields::f64::BaseElement as Felt;
+            let air_tester = Box::new($tester_name {});
+            let length = $trace_length;
+
+            let main_trace = air_tester.build_main_trace(length);
+            let aux_trace = air_tester.build_aux_trace(length);
+            let pub_inputs = air_tester.public_inputs();
+            let trace_info = air_tester.build_trace_info(length);
+            let options = air_tester.build_proof_options();
+
+            let air = <$air_name>::new(trace_info, pub_inputs, options);
+            main_trace.validate::<$air_name, Felt>(&air, aux_trace.as_ref());
+        }
+    };
+}

--- a/air-script/tests/helpers/mod.rs
+++ b/air-script/tests/helpers/mod.rs
@@ -2,6 +2,8 @@ use winter_air::{BatchingMethod, EvaluationFrame, FieldExtension, ProofOptions, 
 use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{AuxTraceWithMetadata, Trace, TraceTable, matrix::ColMatrix};
 
+pub mod macros;
+
 /// We need to encapsulate the trace table in a struct to manually implement the `aux_trace_width`
 /// method of the `Table` trait. Otherwise, using only a TraceTable<Felt> will return an
 /// `aux_trace_width` of 0 even if we provide a non-empty aux trace in `Trace::validate`,

--- a/air-script/tests/indexed_trace_access/test_air.rs
+++ b/air-script/tests/indexed_trace_access/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    indexed_trace_access::indexed_trace_access::{PublicInputs, TraceAccessAir},
+    indexed_trace_access::indexed_trace_access::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -39,17 +40,9 @@ impl AirTester for TraceAccessAirTester {
     }
 }
 
-#[test]
-fn test_indexed_trace_access_air() {
-    let air_tester = Box::new(TraceAccessAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = TraceAccessAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<TraceAccessAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_indexed_trace_access_air,
+    crate::indexed_trace_access::indexed_trace_access::TraceAccessAir,
+    TraceAccessAirTester,
+    1024
+);

--- a/air-script/tests/list_comprehension/test_air.rs
+++ b/air-script/tests/list_comprehension/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    list_comprehension::list_comprehension::{ListComprehensionAir, PublicInputs},
+    list_comprehension::list_comprehension::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -51,17 +52,9 @@ impl AirTester for ListComprehensionAirTester {
     }
 }
 
-#[test]
-fn test_list_comprehension_air() {
-    let air_tester = Box::new(ListComprehensionAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = ListComprehensionAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<ListComprehensionAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_list_comprehension_air,
+    crate::list_comprehension::list_comprehension::ListComprehensionAir,
+    ListComprehensionAirTester,
+    1024
+);

--- a/air-script/tests/list_folding/test_air.rs
+++ b/air-script/tests/list_folding/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    list_folding::list_folding::{ListFoldingAir, PublicInputs},
+    list_folding::list_folding::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -52,17 +53,9 @@ impl AirTester for ListFoldingAirTester {
     }
 }
 
-#[test]
-fn test_list_folding_air() {
-    let air_tester = Box::new(ListFoldingAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = ListFoldingAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<ListFoldingAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_list_folding_air,
+    crate::list_folding::list_folding::ListFoldingAir,
+    ListFoldingAirTester,
+    1024
+);

--- a/air-script/tests/periodic_columns/test_air.rs
+++ b/air-script/tests/periodic_columns/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    periodic_columns::periodic_columns::{PeriodicColumnsAir, PublicInputs},
+    periodic_columns::periodic_columns::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -36,17 +37,9 @@ impl AirTester for PeriodicColumnsAirTester {
     }
 }
 
-#[test]
-fn test_periodic_columns_air() {
-    let air_tester = Box::new(PeriodicColumnsAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = PeriodicColumnsAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<PeriodicColumnsAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_periodic_columns_air,
+    crate::periodic_columns::periodic_columns::PeriodicColumnsAir,
+    PeriodicColumnsAirTester,
+    1024
+);

--- a/air-script/tests/pub_inputs/test_air.rs
+++ b/air-script/tests/pub_inputs/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    pub_inputs::pub_inputs::{PubInputsAir, PublicInputs},
+    pub_inputs::pub_inputs::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -37,17 +38,9 @@ impl AirTester for PubInputsAirTester {
     }
 }
 
-#[test]
-fn test_pub_inputs_air() {
-    let air_tester = Box::new(PubInputsAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = PubInputsAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<PubInputsAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_pub_inputs_air,
+    crate::pub_inputs::pub_inputs::PubInputsAir,
+    PubInputsAirTester,
+    1024
+);

--- a/air-script/tests/selectors/test_air.rs
+++ b/air-script/tests/selectors/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    selectors::selectors_with_evaluators::{PublicInputs, SelectorsAir},
+    selectors::selectors_with_evaluators::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -39,17 +40,9 @@ impl AirTester for SelectorsAirTester {
     }
 }
 
-#[test]
-fn test_selectors_with_evaluators_air() {
-    let air_tester = Box::new(SelectorsAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = SelectorsAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<SelectorsAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_selectors_with_evaluators_air,
+    crate::selectors::selectors_with_evaluators::SelectorsAir,
+    SelectorsAirTester,
+    1024
+);

--- a/air-script/tests/system/test_air.rs
+++ b/air-script/tests/system/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    system::system::{PublicInputs, SystemAir},
+    system::system::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -38,17 +39,4 @@ impl AirTester for SystemAirTester {
     }
 }
 
-#[test]
-fn test_system_air() {
-    let air_tester = Box::new(SystemAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = SystemAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<SystemAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(test_system_air, crate::system::system::SystemAir, SystemAirTester, 1024);

--- a/air-script/tests/trace_col_groups/test_air.rs
+++ b/air-script/tests/trace_col_groups/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    trace_col_groups::trace_col_groups::{PublicInputs, TraceColGroupAir},
+    trace_col_groups::trace_col_groups::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -45,17 +46,9 @@ impl AirTester for TraceColGroupAirTester {
     }
 }
 
-#[test]
-fn test_trace_col_groups_air() {
-    let air_tester = Box::new(TraceColGroupAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = TraceColGroupAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<TraceColGroupAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_trace_col_groups_air,
+    crate::trace_col_groups::trace_col_groups::TraceColGroupAir,
+    TraceColGroupAirTester,
+    1024
+);

--- a/air-script/tests/variables/test_air.rs
+++ b/air-script/tests/variables/test_air.rs
@@ -3,8 +3,9 @@ use winter_math::fields::f64::BaseElement as Felt;
 use winterfell::{Trace, TraceTable};
 
 use crate::{
+    generate_air_test,
     helpers::{AirTester, MyTraceTable},
-    variables::variables::{PublicInputs, VariablesAir},
+    variables::variables::PublicInputs,
 };
 
 #[derive(Clone)]
@@ -39,17 +40,9 @@ impl AirTester for VariablesAirTester {
     }
 }
 
-#[test]
-fn test_variables_air() {
-    let air_tester = Box::new(VariablesAirTester {});
-    let length = 1024;
-
-    let main_trace = air_tester.build_main_trace(length);
-    let aux_trace = air_tester.build_aux_trace(length);
-    let pub_inputs = air_tester.public_inputs();
-    let trace_info = air_tester.build_trace_info(length);
-    let options = air_tester.build_proof_options();
-
-    let air = VariablesAir::new(trace_info, pub_inputs, options);
-    main_trace.validate::<VariablesAir, Felt>(&air, aux_trace.as_ref());
-}
+generate_air_test!(
+    test_variables_air,
+    crate::variables::variables::VariablesAir,
+    VariablesAirTester,
+    1024
+);


### PR DESCRIPTION
Straightforward macro avoiding a bunch of test setup boilerplate.