### PR TITLE
fix(mir/translate): correct return parameter index by removing redundant increment

### DIFF
--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -242,7 +242,6 @@ impl<'a> MirBuilder<'a> {
             params.push(param.clone());
             func = func.parameters(param.clone());
         }
-        i += 1;
         let ret = Parameter::create(i, self.translate_type(&ast_func.return_type), ast_func.span());
         params.push(ret.clone());
 


### PR DESCRIPTION
## Describe your changes

The return Parameter in translate_function_signature was assigned position numParams+1 due to an extra i += 1 before creating the return node. This created a gap in parameter indexing (e.g., with one arg: param.position=0, return.position=2), breaking the expectation of continuous indices and risking incorrect comparisons/hashing and future replacements keyed by position. Removed the redundant increment so return.position == numParams, restoring consistent and predictable indexing.



## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`
