### PR TITLE
feature: add CSE and hoist extension conversions in constraint emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a constant propagation pass after other mir passes (#439).
 - Removed `TraceSegmentId::index()` and replaced segment indexing with `TraceShape<T>`/`FullTraceShape<T>` across ACE codegen, MIR-to-AIR pass, and constraints (#442).
 - Fix regressions on MIR and list_comprehensions (#449).
+- Add CSE and hoist extension conversions in constraint emission (#493).
 
 ## 0.4.0 (2025-06-20)
 

--- a/codegen/winterfell/src/air/graph.rs
+++ b/codegen/winterfell/src/air/graph.rs
@@ -147,3 +147,169 @@ fn binary_op_to_string(
         _ => panic!("unsupported operation"),
     }
 }
+
+// COMMON-SUBEXPRESSION ELIMINATION & CONVERSION HOISTING EMITTER
+// ================================================================================================
+// The functions below generate an expression string along with a list of temporary bindings which
+// should be emitted before using the expression. This reduces duplicate multiplications produced by
+// exponentiation lowering, and factors repeated extension field conversions (E::from(...)).
+
+use std::collections::HashMap;
+
+/// Returns a tuple of (temporary let bindings, final expression string) for the provided node.
+pub(super) fn to_string_with_temps(
+    ir: &Air,
+    node_index: &NodeIndex,
+    trace_segment: TraceSegmentId,
+) -> (Vec<String>, String) {
+    let mut use_counts: HashMap<NodeIndex, usize> = HashMap::new();
+    collect_use_counts(ir, node_index, &mut use_counts);
+
+    let mut cse_temps: HashMap<NodeIndex, String> = HashMap::new();
+    let mut conv_seen: HashMap<String, usize> = HashMap::new();
+    let mut conv_temps: HashMap<String, String> = HashMap::new();
+    let mut temps: Vec<String> = Vec::new();
+    let mut temp_counter: usize = 0;
+
+    let expr = emit_node(
+        ir,
+        node_index,
+        trace_segment,
+        &use_counts,
+        &mut cse_temps,
+        &mut conv_seen,
+        &mut conv_temps,
+        &mut temps,
+        &mut temp_counter,
+    );
+
+    (temps, expr)
+}
+
+fn collect_use_counts(
+    ir: &Air,
+    node_index: &NodeIndex,
+    use_counts: &mut HashMap<NodeIndex, usize>,
+) {
+    *use_counts.entry(*node_index).or_insert(0) += 1;
+    match ir.constraint_graph().node(node_index).op() {
+        Operation::Add(l, r) | Operation::Sub(l, r) | Operation::Mul(l, r) => {
+            collect_use_counts(ir, l, use_counts);
+            collect_use_counts(ir, r, use_counts);
+        },
+        Operation::Value(_) => {},
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_node(
+    ir: &Air,
+    node_index: &NodeIndex,
+    trace_segment: TraceSegmentId,
+    use_counts: &HashMap<NodeIndex, usize>,
+    cse_temps: &mut HashMap<NodeIndex, String>,
+    conv_seen: &mut HashMap<String, usize>,
+    conv_temps: &mut HashMap<String, String>,
+    temps: &mut Vec<String>,
+    temp_counter: &mut usize,
+) -> String {
+    // If this node is a candidate for CSE and has been assigned a temp, return it.
+    if let Some(name) = cse_temps.get(node_index) {
+        return name.clone();
+    }
+
+    match ir.constraint_graph().node(node_index).op() {
+        Operation::Value(v) => {
+            // Delegate to existing value printer, then hoist repeated E::from conversions.
+            let s = v.to_string(ir, ElemType::Ext, trace_segment);
+            if s.starts_with("E::from(") {
+                let count = conv_seen.entry(s.clone()).or_insert(0);
+                *count += 1;
+                if *count >= 2 {
+                    if let Some(name) = conv_temps.get(&s) {
+                        return name.clone();
+                    }
+                    let name = format!("t{}", *temp_counter);
+                    *temp_counter += 1;
+                    temps.push(format!("let {name} = {s};"));
+                    conv_temps.insert(s, name.clone());
+                    return name;
+                }
+            }
+            s
+        },
+        Operation::Add(l, r) | Operation::Sub(l, r) | Operation::Mul(l, r) => {
+            let lhs_str = emit_child(
+                ir,
+                l,
+                node_index,
+                trace_segment,
+                use_counts,
+                cse_temps,
+                conv_seen,
+                conv_temps,
+                temps,
+                temp_counter,
+            );
+            let rhs_str = emit_child(
+                ir,
+                r,
+                node_index,
+                trace_segment,
+                use_counts,
+                cse_temps,
+                conv_seen,
+                conv_temps,
+                temps,
+                temp_counter,
+            );
+
+            let op = ir.constraint_graph().node(node_index).op();
+            let rendered = match op {
+                Operation::Add(..) => format!("{lhs_str} + {rhs_str}"),
+                Operation::Sub(..) => format!("{lhs_str} - {rhs_str}"),
+                Operation::Mul(..) => format!("{lhs_str} * {rhs_str}"),
+                _ => unreachable!(),
+            };
+
+            if use_counts.get(node_index).copied().unwrap_or(1) > 1 {
+                let name = format!("t{}", *temp_counter);
+                *temp_counter += 1;
+                temps.push(format!("let {name} = {rendered};"));
+                cse_temps.insert(*node_index, name.clone());
+                name
+            } else {
+                rendered
+            }
+        },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_child(
+    ir: &Air,
+    child: &NodeIndex,
+    parent: &NodeIndex,
+    trace_segment: TraceSegmentId,
+    use_counts: &HashMap<NodeIndex, usize>,
+    cse_temps: &mut HashMap<NodeIndex, String>,
+    conv_seen: &mut HashMap<String, usize>,
+    conv_temps: &mut HashMap<String, String>,
+    temps: &mut Vec<String>,
+    temp_counter: &mut usize,
+) -> String {
+    let needs_paren = ir.constraint_graph().node(child).op().precedence()
+        < ir.constraint_graph().node(parent).op().precedence();
+    let s = emit_node(
+        ir,
+        child,
+        trace_segment,
+        use_counts,
+        cse_temps,
+        conv_seen,
+        conv_temps,
+        temps,
+        temp_counter,
+    );
+    if needs_paren { format!("({s})") } else { s }
+}

--- a/codegen/winterfell/src/air/transition_constraints.rs
+++ b/codegen/winterfell/src/air/transition_constraints.rs
@@ -1,6 +1,6 @@
 use air_ir::{Air, TraceSegmentId};
 
-use super::{Codegen, ElemType, Impl};
+use super::{Impl, graph::to_string_with_temps};
 
 // HELPERS TO GENERATE THE WINTERFELL TRANSITION CONSTRAINT METHODS
 // ================================================================================================
@@ -55,10 +55,10 @@ pub(super) fn add_fn_evaluate_aux_transition(impl_ref: &mut Impl, ir: &Air) {
 /// the provided codegen function body for each constraint.
 fn add_constraints(func_body: &mut codegen::Function, ir: &Air, trace_segment: TraceSegmentId) {
     for (idx, constraint) in ir.integrity_constraints(trace_segment).iter().enumerate() {
-        func_body.line(format!(
-            "result[{}] = {};",
-            idx,
-            constraint.node_index().to_string(ir, ElemType::Ext, trace_segment)
-        ));
+        let (temps, expr) = to_string_with_temps(ir, constraint.node_index(), trace_segment);
+        for t in temps {
+            func_body.line(t);
+        }
+        func_body.line(format!("result[{idx}] = {expr};"));
     }
 }


### PR DESCRIPTION
## Describe your changes

- Introduce temp-aware emitter (to_string_with_temps) to perform common subexpression elimination (CSE) and factorize repeated E::from(...) into temporaries in codegen/winterfell/src/air/graph.rs.
- Integrate new emitter in evaluate_transition/evaluate_aux_transition via add_constraints to emit temps before result[i] in codegen/winterfell/src/air/transition_constraints.rs.
- Reduces redundant multiplications after exponentiation lowering from PR #352 and avoids repeated base→extension conversions, improving generated code size and evaluation performance.

Fixes #354 



## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`
