### PR TITLE
fix: unwrap Enf safely when combining constraints in MatchOptimizer

### DIFF
--- a/mir/src/passes/unrolling/match_optimizer.rs
+++ b/mir/src/passes/unrolling/match_optimizer.rs
@@ -210,11 +210,15 @@ impl<'a> MatchOptimizer<'a> {
                             Some(Add::create(cur_condition.unwrap(), condition.clone(), span));
                     }
                 }
-                let new_node = Mul::create(
-                    cur_condition.unwrap(),
-                    equivalent_constraints.first().unwrap().1.clone(),
-                    span,
-                );
+                // Multiply the combined selector by the inner expression of the representative
+                // constraint. If the representative is an Enf node, unwrap to its inner expr.
+                let repr = equivalent_constraints.first().unwrap().1.clone();
+                let multiplicand = if let Some(enf_ref) = repr.as_enf() {
+                    enf_ref.expr.clone()
+                } else {
+                    repr
+                };
+                let new_node = Mul::create(cur_condition.unwrap(), multiplicand, span);
 
                 cur_node = match cur_node {
                     Some(existing) => Some(Add::create(existing, new_node, span)),


### PR DESCRIPTION
## Describe your changes

The combined main constraints were constructed by multiplying the selector with the representative constraint node, which could be an Enf, creating Mul(selector, Enf(expr)) under Sub(..., 0). This violates the intended shape where main constraints are pure arithmetic expressions enforced to zero, and makes downstream assumptions brittle. The change unwraps Enf to its inner expression before multiplication so selectors are applied to the arithmetic expr itself, aligning with the documented contract and the handling of bus constraints.