### PR TITLE
Support importing hierarchical modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Allow computed indices (#444).
 - Fix regressions on MIR and list_comprehensions (#449).
 - Fixed a vector unrolling issue in nested match evaluations (#491).
+-  Support importing hierarchical modules (#507).
 
 ## 0.4.0 (2025-06-20)
 

--- a/air/src/graph/cse.rs
+++ b/air/src/graph/cse.rs
@@ -48,7 +48,7 @@ impl AlgebraicGraph {
                 let new_op = match op {
                     Operation::Value(_) => {
                         // Values do not need renumbering, they are leaf nodes
-                        *op
+                        op.clone()
                     },
                     // Note: for Add, Sub, and Mul operations, we assume it's children have already
                     // been handled. This holds because when building the graph, we always insert

--- a/air/src/graph/mod.rs
+++ b/air/src/graph/mod.rs
@@ -187,7 +187,7 @@ impl AlgebraicGraph {
                 | Value::RandomValue(_) => 0,
                 Value::TraceAccess(_) => 1,
                 Value::PeriodicColumn(pc) => {
-                    cycles.insert(pc.name, pc.cycle);
+                    cycles.insert(pc.name.clone(), pc.cycle);
                     0
                 },
             },

--- a/air/src/ir/operation.rs
+++ b/air/src/ir/operation.rs
@@ -3,7 +3,7 @@ use crate::graph::NodeIndex;
 
 /// [Operation] defines the various node types represented
 /// in the [AlgebraicGraph].
-#[derive(Debug, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub enum Operation {
     /// Evaluates to a [Value]
     ///

--- a/air/src/ir/value.rs
+++ b/air/src/ir/value.rs
@@ -4,7 +4,7 @@ use super::*;
 ///
 /// Values are either constant, or evaluated at runtime using the context
 /// provided to an AirScript program (i.e. random values, public inputs, etc.).
-#[derive(Debug, Eq, PartialEq, Copy, Clone, PartialOrd, Ord)]
+#[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
 pub enum Value {
     /// A constant value.
     Constant(u64),
@@ -23,7 +23,7 @@ pub enum Value {
 }
 
 /// Represents an access of a [PeriodicColumn], similar in nature to [TraceAccess]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PeriodicColumnAccess {
     pub name: QualifiedIdentifier,
     pub cycle: usize,

--- a/air/src/passes/translate_from_mir.rs
+++ b/air/src/passes/translate_from_mir.rs
@@ -339,7 +339,7 @@ impl AirBuilder<'_> {
                     },
                     MirValue::PeriodicColumn(periodic_column_access) => {
                         crate::ir::Value::PeriodicColumn(crate::ir::PeriodicColumnAccess {
-                            name: periodic_column_access.name,
+                            name: periodic_column_access.name.clone(),
                             cycle: periodic_column_access.cycle,
                         })
                     },
@@ -392,7 +392,7 @@ impl AirBuilder<'_> {
                     },
                     MirValue::PeriodicColumn(periodic_column_access) => {
                         crate::ir::Value::PeriodicColumn(crate::ir::PeriodicColumnAccess {
-                            name: periodic_column_access.name,
+                            name: periodic_column_access.name.clone(),
                             cycle: periodic_column_access.cycle,
                         })
                     },

--- a/codegen/ace/src/builder.rs
+++ b/codegen/ace/src/builder.rs
@@ -163,7 +163,7 @@ impl CircuitBuilder {
                 self.mul(node_l, node_r)
             },
         };
-        self.air_node_cache.insert(*air_op, node);
+        self.air_node_cache.insert(air_op.clone(), node);
         node
     }
 
@@ -265,7 +265,7 @@ impl CircuitBuilder {
         air: &Air,
         periodic_column: &PeriodicColumnAccess,
     ) -> Option<Node> {
-        let ident = periodic_column.name;
+        let ident = periodic_column.name.clone();
 
         // Check if we have already computed this column's value
         if let Some(node) = self.periodic_columns_cache.get(&ident) {

--- a/codegen/ace/src/tests/quotient.rs
+++ b/codegen/ace/src/tests/quotient.rs
@@ -37,7 +37,7 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
             winter_math::fft::interpolate_poly(&mut poly, &twiddles);
 
             let eval = poly_eval(&poly, z_col);
-            (*ident, QuadFelt::from(eval))
+            (ident.clone(), QuadFelt::from(eval))
         })
         .collect();
 
@@ -62,7 +62,7 @@ pub fn eval_quotient(air: &Air, ace_vars: &AceVars, log_trace_len: u32) -> QuadF
     for node_idx in 0..num_nodes {
         let node: NodeIndex = node_idx.into();
         let op = graph.node(&node).op();
-        let eval = match *op {
+        let eval = match op.clone() {
             Operation::Value(v) => match v {
                 Value::Constant(c) => QuadFelt::from(Felt::new(c)),
                 Value::TraceAccess(access) => {

--- a/docs/src/description/organization.md
+++ b/docs/src/description/organization.md
@@ -56,19 +56,22 @@ Library modules inherit buses declarations of the root module. That is, evaluato
 ## Importing evaluators
 A module can import constants and evaluators from library modules via a `use` statement. For example:
 ```air
-use my_module::my_evaluator
-use my_module::my_constant
+use my_module::my_evaluator;
+use my_module::my_constant;
+use utils::my_second_module::my_second_evaluator;
 ```
 where:
 - `my_module` is a library module located in the same directory as the importing module.
+- `my_second_module` is a library module located in the `./utils` directory compared to the importing module.
 - `my_evaluator` and `my_constant` is an evaluator and a constant defined in `my_module`.
+- `my_second_evaluator` is an evaluator defined in `my_second_module`.
 
 Once an evaluator or a constant is imported, it can be used in the same way as evaluators and constants defined in the importing module.
 
-To import multiple evaluators and constants, multiple `use` statements must be used:
+To import multiple evaluators and constants, multiple `use` statements can be used, or a wildcard can import all the exported symbols:
 ```air
-use my_module::foo
-use my_module::bar
-use my_other_module::baz
+use my_module::foo;
+use my_module::bar;
+use my_other_module::*;
 ```
 `use` statements can appear anywhere in the module file.

--- a/docs/src/description/organization.md
+++ b/docs/src/description/organization.md
@@ -44,7 +44,7 @@ Library modules can be used to split integrity constraint descriptions across mu
 mod example_module
 ```
 where the name of the module must:
-- Be the same as the name of the file in which the library module is defined (e.g., the above module must be located in `example_module.air` file).
+- Be the same as the name of the file in which the library module is defined (e.g., the above module must be located in `example_module.air` file, or alternatively in example_module/mod.air).
 - Be a string consisting of alphanumeric characters and underscores.
 - Start with a letter.
 - End with a newline.

--- a/mir/src/ir/nodes/ops/value.rs
+++ b/mir/src/ir/nodes/ops/value.rs
@@ -174,7 +174,7 @@ impl From<ast::Type> for MirType {
 }
 
 /// Represents an access of a PeriodicColumn, similar in nature to [TraceAccess].
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct PeriodicColumnAccess {
     pub name: QualifiedIdentifier,
     pub cycle: usize,

--- a/mir/src/ir/utils.rs
+++ b/mir/src/ir/utils.rs
@@ -226,7 +226,7 @@ impl Visitor for StripSpansVisitor {
             MirValue::Constant(_) => {},
             MirValue::TraceAccess(_) => {},
             MirValue::PeriodicColumn(v) => {
-                v.name.module.0 = Span::new(SourceSpan::default(), v.name.module.0.item);
+                v.name.module.0 = Span::new(SourceSpan::default(), v.name.module.0.item.clone());
                 match v.name.item {
                     NamespacedIdentifier::Function(f) => {
                         v.name.item = NamespacedIdentifier::Function(Identifier::new(

--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -96,7 +96,7 @@ impl<'a> MirBuilder<'a> {
         self.mir.public_inputs = self.program.public_inputs.clone();
         for (qual_ident, ast_bus) in buses.iter() {
             let bus = self.translate_bus_definition(ast_bus)?;
-            self.mir.constraint_graph_mut().insert_bus(*qual_ident, bus)?;
+            self.mir.constraint_graph_mut().insert_bus(qual_ident.clone(), bus)?;
         }
 
         for (ident, function) in &self.program.functions {
@@ -172,7 +172,7 @@ impl<'a> MirBuilder<'a> {
 
         set_all_ref_nodes(all_params_flatten.clone(), ev.as_owner());
 
-        self.mir.constraint_graph_mut().insert_evaluator(*ident, ev.clone())?;
+        self.mir.constraint_graph_mut().insert_evaluator(ident.clone(), ev.clone())?;
 
         Ok(ev)
     }
@@ -250,7 +250,7 @@ impl<'a> MirBuilder<'a> {
         let func = func.return_type(ret).build();
         set_all_ref_nodes(params.clone(), func.as_owner());
 
-        self.mir.constraint_graph_mut().insert_function(*ident, func.clone())?;
+        self.mir.constraint_graph_mut().insert_function(ident.clone(), func.clone())?;
 
         Ok(func)
     }
@@ -691,7 +691,7 @@ impl<'a> MirBuilder<'a> {
         &mut self,
         access: &'a ast::SymbolAccess,
     ) -> Result<Link<Op>, CompileError> {
-        match access.name {
+        match &access.name {
             // At this point during compilation, fully-qualified identifiers can only possibly refer
             // to a periodic column, as all functions have been inlined, and constants propagated.
             ast::ResolvableIdentifier::Resolved(qual_ident) => {
@@ -700,7 +700,7 @@ impl<'a> MirBuilder<'a> {
                         .value(SpannedMirValue {
                             span: access.span(),
                             value: MirValue::PeriodicColumn(crate::ir::PeriodicColumnAccess::new(
-                                qual_ident,
+                                qual_ident.clone(),
                                 pc.period(),
                             )),
                         })

--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -205,6 +205,12 @@ impl fmt::Display for ConstantExpr {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportLimb {
+    Star,
+    Ident(Identifier),
+}
+
 /// An import declaration
 ///
 /// There can be multiple of these in a given module
@@ -221,7 +227,7 @@ pub enum Import {
 impl Import {
     pub fn module(&self) -> ModuleId {
         match self {
-            Self::All { module } | Self::Partial { module, .. } => *module,
+            Self::All { module } | Self::Partial { module, .. } => module.clone(),
         }
     }
 }

--- a/parser/src/ast/expression.rs
+++ b/parser/src/ast/expression.rs
@@ -132,7 +132,7 @@ impl fmt::Display for NamespacedIdentifier {
 /// Represents an identifier qualified with both its parent module and namespace.
 ///
 /// This represents a globally-unique identity for a declaration
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Spanned)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Spanned)]
 pub struct QualifiedIdentifier {
     pub module: ModuleId,
     #[span]
@@ -157,7 +157,7 @@ impl QualifiedIdentifier {
     pub fn is_builtin(&self) -> bool {
         use crate::symbols;
 
-        if self.module.name() == "$builtin" {
+        if self.module.len() == 1 && self.module[0].name() == "$builtin" {
             match self.item {
                 NamespacedIdentifier::Function(id) => {
                     matches!(id.name(), symbols::Sum | symbols::Prod)
@@ -182,7 +182,7 @@ impl fmt::Display for QualifiedIdentifier {
 }
 
 /// Represents an identifier which requires name resolution at some stage during lowering.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Spanned)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Spanned)]
 pub enum ResolvableIdentifier {
     /// This identifier is resolved to a local binding (i.e. function parameter or let-bound var)
     Local(#[span] Identifier),
@@ -226,7 +226,7 @@ impl ResolvableIdentifier {
     /// resolved/unresolved states
     pub fn module(&self) -> Option<ModuleId> {
         match self {
-            Self::Resolved(qid) => Some(*qid.as_ref()),
+            Self::Resolved(qid) => Some(qid.module.clone()),
             _ => None,
         }
     }
@@ -234,14 +234,14 @@ impl ResolvableIdentifier {
     /// Obtains a [NamespacedIdentifier] from this identifier
     #[inline]
     pub fn namespaced(&self) -> NamespacedIdentifier {
-        (*self).into()
+        self.clone().into()
     }
 
     /// Gets the [QualifiedIdentifier] if this identifier is of type `Resolved`
     #[inline]
     pub fn resolved(&self) -> Option<QualifiedIdentifier> {
         match self {
-            Self::Resolved(qid) => Some(*qid),
+            Self::Resolved(qid) => Some(qid.clone()),
             _ => None,
         }
     }
@@ -1397,7 +1397,10 @@ impl Call {
     }
 
     fn new_builtin(span: SourceSpan, name: &str, args: Vec<Expr>, ty: Type) -> Self {
-        let builtin_module = Identifier::new(SourceSpan::UNKNOWN, Symbol::intern("$builtin"));
+        let builtin_module = ModuleId::new(
+            vec![Identifier::new(SourceSpan::UNKNOWN, Symbol::intern("$builtin"))],
+            SourceSpan::UNKNOWN,
+        );
         let name = Identifier::new(span, Symbol::intern(name));
         let id = QualifiedIdentifier::new(builtin_module, NamespacedIdentifier::Function(name));
         Self {

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -496,22 +496,23 @@ impl Library {
         // to modules in the library. If the module is already in the library, we proceed,
         // if it isn't, then we must parse the desired module from disk, and add it to the
         // library, visiting any of its imports as well.
-        while let Some((module, mut imports)) = worklist.pop_front() {
+        while let Some((_module, mut imports)) = worklist.pop_front() {
             // We attempt to resolve imports on disk relative to the file path of the
             // importing module, if it was parsed from disk. If no path is available,
             // we default to the current working directory.
 
-            let source_dir = match codemap.name(imports.first().unwrap().span().source_id()) {
-                // If we have no source span, default to the current working directory
-                Err(_) => cwd.clone(),
-                // If the file is virtual, then we've either already parsed imports for this module,
-                // or we have to fall back to the current working directory, but we have no relative
-                // path from which to base our search.
-                Ok(FileName::Virtual(_)) => cwd.clone(),
-                Ok(FileName::Real(path)) => {
-                    path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf()
-                },
-            };
+            let (real_path, source_dir) =
+                match codemap.name(imports.first().unwrap().span().source_id()) {
+                    // If we have no source span, default to the current working directory
+                    Err(_) => (false, cwd.clone()),
+                    // If the file is virtual, then we've either already parsed imports for this module,
+                    // or we have to fall back to the current working directory, but we have no relative
+                    // path from which to base our search.
+                    Ok(FileName::Virtual(_)) => (false, cwd.clone()),
+                    Ok(FileName::Real(path)) => {
+                        (true, path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf())
+                    },
+                };
 
             // For each module imported, try to load the module from the library, if it is
             // unavailable we must do extra work to load it into the library, as
@@ -519,12 +520,23 @@ impl Library {
             for import in imports.drain(..) {
                 if !lib.modules.contains_key(&import.clone()) {
                     let mut filename = source_dir.clone();
+                    let mut use_default_mod = false;
                     let items = &import.0.item;
                     if let Some((last, parents)) = items.split_last() {
                         for part in parents {
                             filename = filename.join(part.as_str());
                         }
-                        filename = filename.join(format!("{}.air", last.as_str()));
+                        let path_exist = {
+                            let mut check_path = filename.clone();
+                            check_path = check_path.join(format!("{}.air", last.as_str()));
+                            check_path.exists()
+                        };
+                        if path_exist || !real_path {
+                            filename = filename.join(format!("{}.air", last.as_str()));
+                        } else {
+                            filename = filename.join(last.as_str()).join("mod.air");
+                            use_default_mod = true;
+                        }
                     }
 
                     // Check if the module exists in the codemap first, so that we can add files
@@ -543,15 +555,18 @@ impl Library {
                             // We must check if the file we parsed actually contains a module with
                             // the same name as our import, if not, that's an error
 
-                            let last_import_part = import.0.item.last().unwrap();
-                            let module_name_parts = imported_module.path.0.item.last().unwrap();
-                            if module_name_parts != last_import_part {
-                                diagnostics.diagnostic(Severity::Error)
-                                    .with_message("invalid module declaration")
-                                    .with_primary_label(imported_module.path.span(), "module names must be the same as the name of the file they are defined in")
-                                    .emit();
-                                return Err(SemanticAnalysisError::ImportFailed(import.span()));
+                            if !use_default_mod {
+                                let last_import_part = import.0.item.last().unwrap();
+                                let module_name_parts = imported_module.path.0.item.last().unwrap();
+                                if module_name_parts != last_import_part {
+                                    diagnostics.diagnostic(Severity::Error)
+                                        .with_message("invalid module declaration")
+                                        .with_primary_label(imported_module.path.span(), "module names must be the same as the name of the file they are defined in")
+                                        .emit();
+                                    return Err(SemanticAnalysisError::ImportFailed(import.span()));
+                                }
                             }
+
                             imported_module.path = import.clone();
 
                             // We parsed the module successfully, so add it to the library

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -501,7 +501,7 @@ impl Library {
             // importing module, if it was parsed from disk. If no path is available,
             // we default to the current working directory.
 
-            let source_dir = match codemap.name(module.span().source_id()) {
+            let source_dir = match codemap.name(imports.first().unwrap().span().source_id()) {
                 // If we have no source span, default to the current working directory
                 Err(_) => cwd.clone(),
                 // If the file is virtual, then we've either already parsed imports for this module,

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -15,9 +15,8 @@ use std::{
     sync::Arc,
 };
 
-use miden_diagnostics::{
-    CodeMap, DiagnosticsHandler, FileName, Severity, SourceSpan, Span, Spanned,
-};
+use miden_diagnostics::{CodeMap, DiagnosticsHandler, FileName, Severity, SourceSpan, Span};
+use petgraph::visit::EdgeRef;
 
 pub(crate) use self::display::*;
 pub use self::{
@@ -131,7 +130,16 @@ impl Program {
 
         use crate::sema::DependencyType;
 
-        let mut program = Program::new(root);
+        if root.len() != 1 {
+            diagnostics
+                .diagnostic(Severity::Error)
+                .with_message("root module must be a single identifier")
+                .emit();
+            return Err(SemanticAnalysisError::MissingRoot);
+        }
+        let root_name = root[0];
+
+        let mut program = Program::new(root_name);
 
         // Validate that the root module is contained in the library
         if !library.contains(&root) {
@@ -144,7 +152,10 @@ impl Program {
             mem::swap(&mut program.public_inputs, &mut root_module.public_inputs);
             mem::swap(&mut program.trace_columns, &mut root_module.trace_columns);
             program.buses = BTreeMap::from_iter(root_module.buses.iter().map(|(k, v)| {
-                (QualifiedIdentifier::new(root, NamespacedIdentifier::Binding(*k)), v.clone())
+                (
+                    QualifiedIdentifier::new(root.clone(), NamespacedIdentifier::Binding(*k)),
+                    v.clone(),
+                )
             }));
         }
 
@@ -152,22 +163,27 @@ impl Program {
         let mut modgraph = sema::ModuleGraph::new();
         let mut visited = HashSet::<ModuleId>::default();
         let mut worklist = VecDeque::new();
-        worklist.push_back(root);
+        let mut nodes = BTreeMap::<ModuleId, petgraph::graph::NodeIndex>::new();
+        worklist.push_back(root.clone());
         while let Some(module_name) = worklist.pop_front() {
             // If we haven't visited the imported module yet, add it's imports to the graph
-            if visited.insert(module_name) {
-                modgraph.add_node(module_name);
-
+            if visited.insert(module_name.clone()) {
+                let module_node_index =
+                    get_node_index_or_add(&mut modgraph, &mut nodes, &module_name);
                 if let Some(module) = library.get(&module_name) {
                     for import in module.imports.values() {
-                        let import_module = modgraph.add_node(import.module());
+                        let import_module_node_index =
+                            get_node_index_or_add(&mut modgraph, &mut nodes, &import.module());
                         // If an attempt is made to import the root module, raise an error
-                        if import_module == root {
-                            return Err(SemanticAnalysisError::RootImport(import.module().span()));
+                        if import.module() == root {
+                            return Err(SemanticAnalysisError::RootImport(root.span()));
                         }
 
-                        assert_eq!(modgraph.add_edge(module_name, import_module, ()), None);
-                        worklist.push_back(import_module);
+                        assert!(
+                            !modgraph.contains_edge(module_node_index, import_module_node_index)
+                        );
+                        modgraph.add_edge(module_node_index, import_module_node_index, ());
+                        worklist.push_back(import.module());
                     }
                 } else {
                     return Err(SemanticAnalysisError::MissingModule(module_name));
@@ -181,15 +197,21 @@ impl Program {
         // In each dependency module, we resolve all identifiers in that module to
         // their fully-qualified form, and add edges in the dependency graph which
         // represent what items are referenced from the functions/constraints in that module.
-        let mut deps = sema::DependencyGraph::new();
-        let mut visitor = DfsPostOrder::new(&modgraph, root);
-        while let Some(module_name) = visitor.next(&modgraph) {
+        let mut deps_graph = sema::DependencyGraph::new();
+        let mut deps_nodes = BTreeMap::<QualifiedIdentifier, petgraph::graph::NodeIndex>::new();
+        let root_node_index = get_node_index_or_add(&mut modgraph, &mut nodes, &root);
+        let mut visitor = DfsPostOrder::new(&modgraph, root_node_index);
+        while let Some(module_name_node_index) = visitor.next(&modgraph) {
+            let module_name = modgraph
+                .node_weight(module_name_node_index)
+                .expect("Did not find module in graph");
+
             // Remove the module from the library temporarily, so that we
             // can look up other modules in the library while we modify it
             //
             // NOTE: This will always succeed, or we would have raised an error
             // during semantic analysis
-            let mut module = library.modules.remove(&module_name).unwrap();
+            let mut module = library.modules.remove(module_name).unwrap();
 
             // Resolve imports
             let resolver = sema::ImportResolver::new(diagnostics, &library);
@@ -197,12 +219,18 @@ impl Program {
 
             // Perform semantic analysis on the module, updating the
             // dependency graph with information gathered from this module
-            let analysis =
-                sema::SemanticAnalysis::new(diagnostics, &program, &library, &mut deps, imported);
+            let analysis = sema::SemanticAnalysis::new(
+                diagnostics,
+                &program,
+                &library,
+                &mut deps_graph,
+                &mut deps_nodes,
+                imported,
+            );
             analysis.run(&mut module)?;
 
             // Put the module back
-            library.modules.insert(module.name, module);
+            library.modules.insert(module.path.clone(), module);
         }
 
         // Now that we have a dependency graph for each function/constraint in the root module,
@@ -211,7 +239,7 @@ impl Program {
         // from the boundary_constraints and integrity_constraints sections, or any of the functions
         // in the root module.
         let root_node = QualifiedIdentifier::new(
-            program.name,
+            ModuleId::new(vec![program.name], SourceSpan::UNKNOWN),
             NamespacedIdentifier::Binding(Identifier::new(
                 SourceSpan::UNKNOWN,
                 Symbol::intern("$$root"),
@@ -230,7 +258,7 @@ impl Program {
             }
             for evaluator in root_module.evaluators.values() {
                 root_nodes.push_back(QualifiedIdentifier::new(
-                    root,
+                    root.clone(),
                     NamespacedIdentifier::Function(evaluator.name),
                 ));
             }
@@ -238,40 +266,49 @@ impl Program {
 
         let mut visited = HashSet::<QualifiedIdentifier>::default();
         while let Some(node) = root_nodes.pop_front() {
-            for (_, referenced, dep_type) in
-                deps.edges_directed(node, petgraph::Direction::Outgoing)
-            {
+            let node_index = deps_graph
+                .node_indices()
+                .find(|i| deps_graph.node_weight(*i).unwrap() == &node)
+                .expect("Did not find node in graph");
+            for edges in deps_graph.edges_directed(node_index, petgraph::Direction::Outgoing) {
+                let dep_type = edges.weight();
+                let referenced_node_index = edges.target();
+                let referenced = deps_graph
+                    .node_weight(referenced_node_index)
+                    .expect("Did not find node in graph")
+                    .clone();
+
                 // Avoid spinning infinitely in dependency cycles
-                if !visited.insert(referenced) {
+                if !visited.insert(referenced.clone()) {
                     continue;
                 }
 
                 // Add dependency to program
                 let referenced_module = library.get(&referenced.module).unwrap();
-                let id = referenced.item.id();
+                let id = referenced.clone().item.id();
                 match dep_type {
                     DependencyType::Constant => {
                         program
                             .constants
-                            .entry(referenced)
+                            .entry(referenced.clone())
                             .or_insert_with(|| referenced_module.constants[&id].clone());
                     },
                     DependencyType::Evaluator => {
                         program
                             .evaluators
-                            .entry(referenced)
+                            .entry(referenced.clone())
                             .or_insert_with(|| referenced_module.evaluators[&id].clone());
                     },
                     DependencyType::Function => {
                         program
                             .functions
-                            .entry(referenced)
+                            .entry(referenced.clone())
                             .or_insert_with(|| referenced_module.functions[&id].clone());
                     },
                     DependencyType::PeriodicColumn => {
                         program
                             .periodic_columns
-                            .entry(referenced)
+                            .entry(referenced.clone())
                             .or_insert_with(|| referenced_module.periodic_columns[&id].clone());
                     },
                 }
@@ -319,7 +356,7 @@ impl fmt::Display for Program {
         if !self.periodic_columns.is_empty() {
             writeln!(f, "periodic_columns {{")?;
             for (qid, column) in self.periodic_columns.iter() {
-                if qid.module == self.name {
+                if qid.module.0.item == vec![self.name] {
                     writeln!(f, "    {}: {}", &qid.item, DisplayList(column.values.as_slice()))?;
                 } else {
                     writeln!(f, "    {}: {}", qid, DisplayList(column.values.as_slice()))?;
@@ -331,7 +368,7 @@ impl fmt::Display for Program {
 
         if !self.constants.is_empty() {
             for (qid, constant) in self.constants.iter() {
-                if qid.module == self.name {
+                if qid.module.0.item == vec![self.name] {
                     writeln!(f, "const {} = {}", &qid.item, &constant.value)?;
                 } else {
                     writeln!(f, "const {} = {}", qid, &constant.value)?;
@@ -356,7 +393,7 @@ impl fmt::Display for Program {
 
         for (qid, evaluator) in self.evaluators.iter() {
             f.write_str("ev ")?;
-            if qid.module == self.name {
+            if qid.module.0.item == vec![self.name] {
                 writeln!(f, "{}{}", &qid.item, DisplayTuple(evaluator.params.as_slice()))?;
             } else {
                 writeln!(f, "{}{}", qid, DisplayTuple(evaluator.params.as_slice()))?;
@@ -371,7 +408,7 @@ impl fmt::Display for Program {
 
         for (qid, function) in self.functions.iter() {
             f.write_str("fn ")?;
-            if qid.module == self.name {
+            if qid.module.0.item == vec![self.name] {
                 writeln!(f, "{}{}", &qid.item, DisplayTypedTuple(function.params.as_slice()))?;
             } else {
                 writeln!(f, "{}{}", qid, DisplayTypedTuple(function.params.as_slice()))?;
@@ -403,7 +440,7 @@ impl Library {
     ) -> Result<Self, SemanticAnalysisError> {
         use std::collections::hash_map::Entry;
 
-        let mut lib = Library::default();
+        let mut lib: Library = Library::default();
 
         if modules.is_empty() {
             return Ok(lib);
@@ -412,18 +449,17 @@ impl Library {
         // Register all parsed modules first
         let mut found_duplicate = None;
         for module in modules.drain(..) {
-            match lib.modules.entry(module.name) {
+            match lib.modules.entry(module.path.clone()) {
                 Entry::Occupied(entry) => {
-                    let prev_span = entry.key().span();
-                    found_duplicate = Some(prev_span);
+                    found_duplicate = Some(entry.key().span());
                     diagnostics
                         .diagnostic(Severity::Error)
                         .with_message("conflicting module definitions")
                         .with_primary_label(
-                            module.name.span(),
+                            module.path.span(),
                             "this module name is already in use",
                         )
-                        .with_secondary_label(prev_span, "originally defined here")
+                        .with_secondary_label(entry.key().span(), "originally defined here")
                         .emit();
                 },
                 Entry::Vacant(entry) => {
@@ -447,11 +483,10 @@ impl Library {
                     None
                 } else {
                     let imports = module.imports.values().map(|i| i.module()).collect::<Vec<_>>();
-                    Some((*name, imports))
+                    Some((name.clone(), imports))
                 }
             })
             .collect::<VecDeque<_>>();
-
         // Cache the current working directory for use in constructing file paths in case
         // we need to parse referenced modules from disk, and do not have a file path associated
         // with the importing module with which to derive the import path.
@@ -465,6 +500,7 @@ impl Library {
             // We attempt to resolve imports on disk relative to the file path of the
             // importing module, if it was parsed from disk. If no path is available,
             // we default to the current working directory.
+
             let source_dir = match codemap.name(module.span().source_id()) {
                 // If we have no source span, default to the current working directory
                 Err(_) => cwd.clone(),
@@ -481,8 +517,16 @@ impl Library {
             // unavailable we must do extra work to load it into the library, as
             // described above.
             for import in imports.drain(..) {
-                if let Entry::Vacant(entry) = lib.modules.entry(import) {
-                    let filename = source_dir.join(format!("{}.air", import.as_str()));
+                if !lib.modules.contains_key(&import.clone()) {
+                    let mut filename = source_dir.clone();
+                    let items = &import.0.item;
+                    if let Some((last, parents)) = items.split_last() {
+                        for part in parents {
+                            filename = filename.join(part.as_str());
+                        }
+                        filename = filename.join(format!("{}.air", last.as_str()));
+                    }
+
                     // Check if the module exists in the codemap first, so that we can add files
                     // directly to the codemap during testing for convenience
                     let result = match codemap.get_by_name(&FileName::Real(filename.clone())) {
@@ -491,28 +535,35 @@ impl Library {
                             crate::parse_module_from_file(diagnostics, codemap.clone(), &filename)
                         },
                     };
+
                     match result {
                         Ok(imported_module) => {
+                            let mut imported_module = imported_module;
+
                             // We must check if the file we parsed actually contains a module with
                             // the same name as our import, if not, that's an error
-                            if imported_module.name != import {
+
+                            let last_import_part = import.0.item.last().unwrap();
+                            let module_name_parts = imported_module.path.0.item.last().unwrap();
+                            if module_name_parts != last_import_part {
                                 diagnostics.diagnostic(Severity::Error)
                                     .with_message("invalid module declaration")
-                                    .with_primary_label(imported_module.name.span(), "module names must be the same as the name of the file they are defined in")
+                                    .with_primary_label(imported_module.path.span(), "module names must be the same as the name of the file they are defined in")
                                     .emit();
                                 return Err(SemanticAnalysisError::ImportFailed(import.span()));
-                            } else {
-                                // We parsed the module successfully, so add it to the library
-                                if !imported_module.imports.is_empty() {
-                                    let imports = imported_module
-                                        .imports
-                                        .values()
-                                        .map(|i| i.module())
-                                        .collect::<Vec<_>>();
-                                    worklist.push_back((imported_module.name, imports));
-                                }
-                                entry.insert(imported_module);
                             }
+                            imported_module.path = import.clone();
+
+                            // We parsed the module successfully, so add it to the library
+                            if !imported_module.imports.is_empty() {
+                                let imports = imported_module
+                                    .imports
+                                    .values()
+                                    .map(|i| i.module())
+                                    .collect::<Vec<_>>();
+                                worklist.push_back((imported_module.path.clone(), imports));
+                            }
+                            lib.modules.insert(imported_module.path.clone(), imported_module);
                         },
                         Err(ParseError::Failed) => {
                             // Nothing interesting to emit as a diagnostic here, so just return an
@@ -553,4 +604,22 @@ impl Library {
     pub fn get_mut(&mut self, module: &ModuleId) -> Option<&mut Module> {
         self.modules.get_mut(module)
     }
+
+    pub fn get_submodules_of(&self, module: &ModuleId) -> Vec<ModuleId> {
+        self.modules.keys().filter(|m| m.is_submodule_of(module)).cloned().collect()
+    }
+}
+
+/// Adds the given module to the module graph if it does not already exist,
+/// returning the corresponding node index.
+fn get_node_index_or_add(
+    modgraph: &mut sema::ModuleGraph,
+    nodes: &mut BTreeMap<ModuleId, petgraph::graph::NodeIndex>,
+    module_name: &ModuleId,
+) -> petgraph::graph::NodeIndex {
+    nodes.get(module_name).cloned().unwrap_or_else(|| {
+        let index = modgraph.add_node(module_name.clone());
+        nodes.insert(module_name.clone(), index);
+        index
+    })
 }

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -217,8 +217,15 @@ impl Program {
             let resolver = sema::ImportResolver::new(diagnostics, &library);
             let imported = resolver.run(&mut module)?;
 
-            // Perform semantic analysis on the module, updating the
-            // dependency graph with information gathered from this module
+            // Perform semantic analysis on the module, updating the dependency graph with
+            // information gathered from this module. The dependency graph is built up
+            // incrementally as we analyze each module, each node is a fully-qualified identifier
+            // representing an item in the program, and edges represent dependencies between those
+            // items (e.g. a constant is used in a function).
+            //
+            // NOTE: nodes are stored in `deps_nodes` and accessed/added to the graph as needed
+            // through `NodeIndex` type to reference them (as QualifiedIdentifier does not implement
+            // Copy).
             let analysis = sema::SemanticAnalysis::new(
                 diagnostics,
                 &program,
@@ -501,18 +508,19 @@ impl Library {
             // importing module, if it was parsed from disk. If no path is available,
             // we default to the current working directory.
 
-            let (real_path, source_dir) =
-                match codemap.name(imports.first().unwrap().span().source_id()) {
-                    // If we have no source span, default to the current working directory
-                    Err(_) => (false, cwd.clone()),
-                    // If the file is virtual, then we've either already parsed imports for this module,
-                    // or we have to fall back to the current working directory, but we have no relative
-                    // path from which to base our search.
-                    Ok(FileName::Virtual(_)) => (false, cwd.clone()),
-                    Ok(FileName::Real(path)) => {
-                        (true, path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf())
-                    },
-                };
+            let (real_path, source_dir) = match codemap
+                .name(imports.first().unwrap().span().source_id())
+            {
+                // If we have no source span, default to the current working directory
+                Err(_) => (false, cwd.clone()),
+                // If the file is virtual, then we've either already parsed imports for this module,
+                // or we have to fall back to the current working directory, but we have no relative
+                // path from which to base our search.
+                Ok(FileName::Virtual(_)) => (false, cwd.clone()),
+                Ok(FileName::Real(path)) => {
+                    (true, path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf())
+                },
+            };
 
             // For each module imported, try to load the module from the library, if it is
             // unavailable we must do extra work to load it into the library, as

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -7,7 +7,8 @@ use miden_diagnostics::{DiagnosticsHandler, Severity, SourceSpan, Span, Spanned}
 
 use crate::{ast::*, sema::SemanticAnalysisError};
 
-/// This is a type alias used to clarify that an identifier refers to a module
+/// This is a type alias used to clarify that a module is referenced by a sequence of identifiers
+/// representing its path in the module hierarchy (e.g., `foo::bar::baz`).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Spanned)]
 pub struct ModuleId(pub Span<Vec<Identifier>>);
 

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -1,11 +1,59 @@
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    ops::Index,
+};
 
 use miden_diagnostics::{DiagnosticsHandler, Severity, SourceSpan, Span, Spanned};
 
 use crate::{ast::*, sema::SemanticAnalysisError};
 
 /// This is a type alias used to clarify that an identifier refers to a module
-pub type ModuleId = Identifier;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Spanned)]
+pub struct ModuleId(pub Span<Vec<Identifier>>);
+
+impl ModuleId {
+    pub fn new(identifiers: Vec<Identifier>, span: SourceSpan) -> Self {
+        Self(Span::new(span, identifiers))
+    }
+
+    /// Returns the span of this module identifier
+    pub fn span(&self) -> SourceSpan {
+        self.0.span()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.item.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.item.is_empty()
+    }
+
+    /// Returns true if this module identifier is a submodule of another module identifier.
+    /// For example, `foo::bar` is a submodule of `foo`. Note that a module is considered a
+    /// submodule of itself.
+    pub fn is_submodule_of(&self, parent_module: &ModuleId) -> bool {
+        if self.len() < parent_module.len() {
+            return false;
+        }
+        self.0.item.iter().zip(parent_module.0.item.iter()).all(|(a, b)| a == b)
+    }
+}
+
+impl Index<usize> for ModuleId {
+    type Output = Identifier;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0.item[index]
+    }
+}
+
+impl std::fmt::Display for ModuleId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let names: Vec<&str> = self.0.item.iter().map(|id| id.as_str()).collect();
+        write!(f, "{}", names.join("::"))
+    }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ModuleType {
@@ -48,7 +96,7 @@ pub enum ModuleType {
 pub struct Module {
     #[span]
     pub span: SourceSpan,
-    pub name: ModuleId,
+    pub path: ModuleId,
     pub ty: ModuleType,
     pub imports: BTreeMap<ModuleId, Import>,
     pub constants: BTreeMap<Identifier, Constant>,
@@ -71,10 +119,10 @@ impl Module {
     /// the caller to guarantee that they construct a valid module that upholds those
     /// guarantees, otherwise it is expected that compilation will panic at some point down
     /// the line.
-    pub fn new(ty: ModuleType, span: SourceSpan, name: ModuleId) -> Self {
+    pub fn new(ty: ModuleType, span: SourceSpan, path: ModuleId) -> Self {
         Self {
             span,
-            name,
+            path,
             ty,
             imports: Default::default(),
             constants: Default::default(),
@@ -99,10 +147,10 @@ impl Module {
         diagnostics: &DiagnosticsHandler,
         ty: ModuleType,
         span: SourceSpan,
-        name: Identifier,
+        path: ModuleId,
         mut declarations: Vec<Declaration>,
     ) -> Result<Self, SemanticAnalysisError> {
-        let mut module = Self::new(ty, span, name);
+        let mut module = Self::new(ty, span, path);
 
         // Keep track of named items in this module while building it from
         // the set of declarations we received. We want to produce modules
@@ -198,12 +246,13 @@ impl Module {
         use std::collections::btree_map::Entry;
 
         let span = import.span();
-        match import.item {
-            Import::All { module: name } => {
-                if name == self.name {
-                    return Err(SemanticAnalysisError::ImportSelf(name.span()));
+        match import.item.clone() {
+            Import::All { module: path } => {
+                if path == self.path {
+                    return Err(SemanticAnalysisError::ImportSelf(path.span()));
                 }
-                match self.imports.entry(name) {
+
+                match self.imports.entry(path.clone()) {
                     Entry::Occupied(mut entry) => {
                         let first = entry.key().span();
                         match entry.get_mut() {
@@ -222,7 +271,7 @@ impl Module {
                                         .with_message("redundant item import")
                                         .with_primary_label(item.span(), "this import is redundant")
                                         .with_secondary_label(
-                                            name.span(),
+                                            path.span(),
                                             "because this import imports all items already",
                                         )
                                         .emit();
@@ -238,17 +287,17 @@ impl Module {
 
                 Ok(())
             },
-            Import::Partial { module: name, mut items } => {
-                if name == self.name {
-                    return Err(SemanticAnalysisError::ImportSelf(name.span()));
+            Import::Partial { module: path, mut items } => {
+                if path == self.path {
+                    return Err(SemanticAnalysisError::ImportSelf(path.span()));
                 }
-                match self.imports.entry(name) {
+                match self.imports.entry(path.clone()) {
                     Entry::Occupied(mut entry) => match entry.get_mut() {
                         Import::All { module: prev } => {
                             diagnostics
                                 .diagnostic(Severity::Warning)
                                 .with_message("redundant module import")
-                                .with_primary_label(name.span(), "this import is redundant")
+                                .with_primary_label(path.span(), "this import is redundant")
                                 .with_secondary_label(
                                     prev.span(),
                                     "because this import includes all items already",
@@ -304,7 +353,7 @@ impl Module {
                                 return Err(SemanticAnalysisError::NameConflict(item.span()));
                             }
                         }
-                        entry.insert(Import::Partial { module: name, items });
+                        entry.insert(Import::Partial { module: path, items });
                     },
                 }
 
@@ -385,6 +434,8 @@ impl Module {
             conflicting_declaration(diagnostics, "function", prev.span(), function.name.span());
             return Err(SemanticAnalysisError::NameConflict(function.name.span()));
         }
+
+        println!("Declared function: {:?}", function.name);
 
         self.functions.insert(function.name, function);
 
@@ -589,7 +640,7 @@ impl Module {
 impl Eq for Module {}
 impl PartialEq for Module {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
+        self.path == other.path
             && self.ty == other.ty
             && self.imports == other.imports
             && self.constants == other.constants

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -38,7 +38,7 @@ pub Source: Source = {
 
 pub Program: Program = {
     <root:Root> <modules:Module*> =>? {
-        let root_name = root.name;
+        let root_name = root.path.clone();
         let mut modules = modules;
         modules.push(root);
         let library = match Library::new(diagnostics, codemap.clone(), modules) {
@@ -57,14 +57,14 @@ pub AnyModule: Module = {
 
 Root: Module = {
     <l:@L> "def" <name:Identifier> <decls:Declaration*> <r:@R> =>? {
-        Module::from_declarations(diagnostics, ModuleType::Root, span!(l, r), name, decls)
+        Module::from_declarations(diagnostics, ModuleType::Root, span!(l, r), ModuleId::new(vec![name], name.span()), decls)
             .map_err(|err| ParseError::Analysis(err).into())
     }
 }
 
 Module: Module = {
     <l:@L> "mod" <name:Identifier> <decls:Declaration*> <r:@R> =>? {
-        Module::from_declarations(diagnostics, ModuleType::Library, span!(l, r), name, decls)
+        Module::from_declarations(diagnostics, ModuleType::Library, span!(l, r), ModuleId::new(vec![name], name.span()), decls)
             .map_err(|err| ParseError::Analysis(err).into())
     }
 }
@@ -82,13 +82,51 @@ Declaration: Declaration = {
     <IntegrityConstraints> => Declaration::IntegrityConstraints(<>),
 }
 
+// Import parses a Vec<ImportLimb> separated by '::', where ImportLimb is Identifier or '*' (only as last limb)
 Import: Span<Import> = {
-    <l:@L> "use" <module:Identifier> "::" "*" ";" <r:@R> => Span::new(span!(l, r), Import::All { module: Identifier::new(span!(l, r), module.name()) }),
-    <l:@L> "use" <module:Identifier> "::" <item:Identifier> ";" <r:@R> => {
-        let mut items: HashSet<Identifier> = HashSet::default();
-        items.insert(item);
-        Span::new(span!(l, r), Import::Partial { module, items })
+    <l:@L> "use" <limbs:ImportPath> ";" <r:@R> => {
+        let (last_limb, parents) = limbs.split_last().expect("Imports need at least one path limb");
+        match last_limb {
+            ImportLimb::Star => {
+                let mut limbs_ident = vec![];
+                for parent in parents {
+                    match parent {
+                        ImportLimb::Star => unreachable!(),
+                        ImportLimb::Ident(ident) => limbs_ident.push(*ident)
+                    }
+                }
+                Span::new(span!(l, r), Import::All { module: ModuleId::new(limbs_ident, span!(l, r)) })
+            }
+            ImportLimb::Ident(item) => {
+                let mut limbs_ident = vec![];
+                for parent in parents {
+                    match parent {
+                        ImportLimb::Star => unreachable!(),
+                        ImportLimb::Ident(ident) => limbs_ident.push(*ident)
+                    }
+                }
+                let mut items: HashSet<Identifier> = HashSet::default();
+                items.insert(*item);
+                Span::new(span!(l, r), Import::Partial { module: ModuleId::new(limbs_ident, span!(l, r)), items })
+            }
+        }
     }
+}
+
+// ImportPath: Vec<ImportLimb> separated by '::' (single right-recursive rule)
+ImportPath: Vec<ImportLimb> = {
+    <head:ImportLimb> => vec![head],
+    <head:ImportLimb> "::" <tail:ImportPath> => {
+        let mut v = vec![head];
+        v.extend(tail);
+        v
+    }
+}
+
+// ImportLimb: either an identifier or '*', but '*' only allowed as last limb
+ImportLimb: ImportLimb = {
+    "*" => ImportLimb::Star,
+    <id:Identifier> => ImportLimb::Ident(id),
 }
 
 // TRACE COLUMNS

--- a/parser/src/parser/tests/arithmetic_ops.rs
+++ b/parser/src/parser/tests/arithmetic_ops.rs
@@ -16,7 +16,7 @@ fn single_addition() {
         enf clk' + clk = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -39,7 +39,7 @@ fn multi_addition() {
         enf clk' + clk + 2 = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -62,7 +62,7 @@ fn single_subtraction() {
         enf clk' - clk = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -85,7 +85,7 @@ fn multi_subtraction() {
         enf clk' - clk - 1 = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -108,7 +108,7 @@ fn single_multiplication() {
         enf clk' * clk = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -131,7 +131,7 @@ fn multi_multiplication() {
         enf clk' * clk * 2 = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -154,7 +154,7 @@ fn unit_with_parens() {
         enf (2) + 1 = 3;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -177,7 +177,7 @@ fn ops_with_parens() {
         enf (clk' + clk) * 2 = 4;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -200,7 +200,7 @@ fn const_exponentiation() {
         enf clk'^2 = 1;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -223,7 +223,7 @@ fn non_const_exponentiation() {
         enf clk'^(clk + 2) = 1;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -270,7 +270,7 @@ fn multi_arithmetic_ops_same_precedence() {
         enf clk' - clk - 2 + 1 = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -302,7 +302,7 @@ fn multi_arithmetic_ops_different_precedence() {
     // 3. Addition/Subtraction
     // These operations are evaluated in the order of decreasing precedence.
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(
@@ -334,7 +334,7 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
     // 3. Multiplication
     // 4. Addition/Subtraction
     // These operations are evaluated in the order of decreasing precedence.
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(test),
         EvaluatorFunction::new(

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -52,7 +52,7 @@ integrity_constraints {
 ///
 /// This is used as a common base for most tests in this module
 fn test_module() -> Module {
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));

--- a/parser/src/parser/tests/buses.rs
+++ b/parser/src/parser/tests/buses.rs
@@ -56,7 +56,7 @@ fn buses() {
     "
     );
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     add_base_expectations(&mut expected);
     add_base_boundary_expectation(&mut expected);
     add_base_integrity_expectation(&mut expected);
@@ -91,7 +91,7 @@ fn boundary_constraints_buses() {
     "
     );
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     add_base_expectations(&mut expected);
     add_base_integrity_expectation(&mut expected);
     expected
@@ -135,7 +135,7 @@ fn integrity_constraints_buses() {
     "
     );
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     add_base_expectations(&mut expected);
     add_base_boundary_expectation(&mut expected);
     expected

--- a/parser/src/parser/tests/calls.rs
+++ b/parser/src/parser/tests/calls.rs
@@ -14,7 +14,7 @@ fn call_fold_identifier() {
         enf a = x + y;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     let body = vec![let_!(x = expr!(call!(sum(expr!(access!(c))))) =>
                   let_!(y = expr!(call!(prod(expr!(access!(c))))) =>
                         enforce!(eq!(access!(a), add!(access!(x), access!(y))))))];
@@ -42,7 +42,7 @@ fn call_fold_vector_literal() {
         enf a = x + y;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     let body = vec![let_!(x = expr!(call!(sum(vector!(access!(a), access!(b), access!(c[0]))))) =>
                   let_!(y = expr!(call!(prod(vector!(access!(a), access!(b), access!(c[0]))))) =>
                         enforce!(eq!(access!(a), add!(access!(x), access!(y))))))];
@@ -70,7 +70,7 @@ fn call_fold_list_comprehension() {
         enf a = x + y;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     let body = vec![
         let_!(x = expr!(call!(sum(lc!(((col, expr!(access!(c)))) => exp!(access!(col), int!(7))).into()))) =>
                   let_!(y = expr!(call!(prod(lc!(((col, expr!(access!(c)))) => exp!(access!(col), int!(7))).into()))) =>

--- a/parser/src/parser/tests/computed_indices.rs
+++ b/parser/src/parser/tests/computed_indices.rs
@@ -26,7 +26,7 @@ fn basic_computed_indices() {
         enf a = x[1 + 1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -72,7 +72,7 @@ fn basic_computed_indices_in_lc() {
         enf a = y[1 + 1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -119,7 +119,7 @@ fn computed_indices_in_lc() {
         enf a = y[1 + 1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",

--- a/parser/src/parser/tests/constants.rs
+++ b/parser/src/parser/tests/constants.rs
@@ -14,7 +14,7 @@ fn constants_scalars() {
     const A = 1;
     const B = 2;";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.constants.insert(
         ident!(A),
         Constant::new(SourceSpan::UNKNOWN, ident!(A), ConstantExpr::Scalar(1)),
@@ -34,7 +34,7 @@ fn constants_vectors() {
     const A = [1, 2, 3, 4];
     const B = [5, 6, 7, 8];";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.constants.insert(
         ident!(A),
         Constant::new(SourceSpan::UNKNOWN, ident!(A), ConstantExpr::Vector(vec![1, 2, 3, 4])),
@@ -54,7 +54,7 @@ fn constants_matrices() {
     const A = [[1, 2], [3, 4]];
     const B = [[5, 6], [7, 8]];";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.constants.insert(
         ident!(A),
         Constant::new(

--- a/parser/src/parser/tests/evaluators.rs
+++ b/parser/src/parser/tests/evaluators.rs
@@ -15,7 +15,7 @@ fn ev_fn_main_cols() {
         enf clk' = clk + 1;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.evaluators.insert(
         ident!(advance_clock),
         EvaluatorFunction::new(
@@ -49,7 +49,7 @@ fn ev_fn_call_simple() {
         enf advance_clock([clk]);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
@@ -89,7 +89,7 @@ fn ev_fn_call() {
         enf advance_clock([a, b[1..3], c[2..4]]);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -123,7 +123,7 @@ fn ev_fn_call_inside_ev_fn() {
         enf advance_clock([clk]);
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     let body = vec![enforce!(call!(advance_clock(vector!(access!(clk)))))];
     expected.evaluators.insert(
         ident!(ev_func),
@@ -159,7 +159,7 @@ fn ev_fn_call_with_more_than_two_args() {
         enf advance_clock([a], [b], [c]);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",

--- a/parser/src/parser/tests/functions.rs
+++ b/parser/src/parser/tests/functions.rs
@@ -15,7 +15,7 @@ fn fn_def_with_scalars() {
         return a + b;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.functions.insert(
         ident!(fn_with_scalars),
         Function::new(
@@ -38,7 +38,7 @@ fn fn_def_with_vectors() {
         return [x + y for (x, y) in (a, b)];
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.functions.insert(
         ident!(fn_with_vectors),
         Function::new(
@@ -78,7 +78,7 @@ fn fn_use_scalars_and_vectors() {
             enf a' = fn_with_scalars_and_vectors(a, b);
         }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(root));
 
     expected.functions.insert(
         ident!(fn_with_scalars_and_vectors),
@@ -145,7 +145,7 @@ fn fn_call_in_fn() {
         enf a' = fold_scalar_and_vec(a, b);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(root));
 
     expected.functions.insert(
         ident!(fold_vec),
@@ -227,7 +227,7 @@ fn fn_call_in_ev() {
         enf evaluator(a, b);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(root));
 
     expected.functions.insert(
         ident!(fold_vec),
@@ -312,7 +312,7 @@ fn fn_as_lc_iterables() {
         enf a' = sum([operation(x, y) for (x, y) in (a, b)]);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(root));
 
     expected.functions.insert(
         ident!(operation),
@@ -383,7 +383,7 @@ fn fn_call_in_binary_ops() {
         enf b[0]' = b[0] * operation(a, b);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(root));
 
     expected.functions.insert(
         ident!(operation),
@@ -459,7 +459,7 @@ fn fn_call_in_vector_def() {
         enf b[0]' = d[1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(root));
 
     expected.functions.insert(
         ident!(operation),

--- a/parser/src/parser/tests/input/import_example.air
+++ b/parser/src/parser/tests/input/import_example.air
@@ -6,6 +6,9 @@ use foo::*;
 # Import just `bar_constraint` from bar
 use bar::bar_constraint;
 
+# Import just `are_all_binary` from utils/binary
+use utils::binary::are_all_binary;
+
 trace_columns {
     main: [clk, fmp, ctx],
 }
@@ -17,6 +20,8 @@ public_inputs {
 integrity_constraints {
     enf foo_constraint([clk]);
     enf bar_constraint([clk]);
+    enf are_all_binary([clk, fmp, ctx]);
+
 }
 
 boundary_constraints {

--- a/parser/src/parser/tests/input/utils/binary.air
+++ b/parser/src/parser/tests/input/utils/binary.air
@@ -1,0 +1,10 @@
+
+mod binary
+
+ev is_binary([x]) {
+    enf x^2 = x;
+}
+
+ev are_all_binary([c[3]]) {
+    enf is_binary([c]) for c in c;
+}

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -27,7 +27,7 @@ fn integrity_constraints() {
         enf clk' = clk + 1;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
@@ -76,7 +76,7 @@ fn integrity_constraints_with_buses() {
         q.remove(1, 2) with 2;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
@@ -180,7 +180,7 @@ fn multiple_integrity_constraints() {
         enf clk' - clk = 1;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
@@ -226,7 +226,7 @@ fn integrity_constraint_with_periodic_col() {
         enf k0 + b = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(b, 1)]));
@@ -272,7 +272,7 @@ fn integrity_constraint_with_constants() {
         enf clk + A = B[1] + C[1][1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
@@ -320,7 +320,7 @@ fn integrity_constraint_with_variables() {
         enf clk + a = b[1] + c[1][1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
@@ -362,7 +362,7 @@ fn integrity_constraint_with_indexed_trace_access() {
         enf $main[0]' = $main[1] + 1;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(a, 1), (b, 1)]));
@@ -404,7 +404,7 @@ fn ic_comprehension_one_iterable_identifier() {
         enf x = a + b for x in c;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -447,7 +447,7 @@ fn ic_comprehension_one_iterable_range() {
         enf x = a + b for x in (1..4);
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -490,7 +490,7 @@ fn ic_comprehension_with_selectors() {
         enf x = a + b for x in c when s[0] & s[1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -537,7 +537,7 @@ fn ic_comprehension_with_evaluator_call() {
         enf is_binary([x]) for x in c;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -593,7 +593,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
         enf is_binary([x]) for x in c when s[0] & s[1];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -652,7 +652,7 @@ fn ic_match_constraint() {
         };
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -30,7 +30,7 @@ fn bc_one_iterable_identifier_lc() {
         enf a.first = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -76,7 +76,7 @@ fn bc_identifier_and_range_lc() {
         enf a.first = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.constants.insert(ident!(THREE), constant!(THREE = 3));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
@@ -121,7 +121,7 @@ fn bc_iterable_slice_lc() {
         enf a.first = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -163,7 +163,7 @@ fn bc_two_iterable_identifier_lc() {
         enf a.first = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -207,7 +207,7 @@ fn bc_multiple_iterables_lc() {
         enf a.first = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -256,7 +256,7 @@ fn ic_one_iterable_identifier_lc() {
         enf a = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -303,7 +303,7 @@ fn ic_iterable_identifier_range_lc() {
         enf a = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -349,7 +349,7 @@ fn ic_iterable_slice_lc() {
         enf a = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -393,7 +393,7 @@ fn ic_two_iterable_identifier_lc() {
         enf a = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -439,7 +439,7 @@ fn ic_multiple_iterables_lc() {
         enf a = x[0] + x[1] + x[2] + x[3];
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -27,6 +27,18 @@ macro_rules! assert_module_error {
     };
 }
 
+macro_rules! module_ident {
+    ($name:ident) => {
+        ModuleId::new(
+            vec![Identifier::new(
+                miden_diagnostics::SourceSpan::UNKNOWN,
+                crate::Symbol::intern(stringify!($name)),
+            )],
+            miden_diagnostics::SourceSpan::UNKNOWN,
+        )
+    };
+}
+
 macro_rules! ident {
     ($name:ident) => {
         Identifier::new(
@@ -40,7 +52,10 @@ macro_rules! ident {
     };
 
     ($module:ident, $name:ident) => {
-        QualifiedIdentifier::new(ident!($module), NamespacedIdentifier::Binding(ident!($name)))
+        QualifiedIdentifier::new(
+            module_ident!($module),
+            NamespacedIdentifier::Binding(ident!($name)),
+        )
     };
 }
 
@@ -50,7 +65,10 @@ macro_rules! function_ident {
     };
 
     ($module:ident, $name:ident) => {
-        QualifiedIdentifier::new(ident!($module), NamespacedIdentifier::Function(ident!($name)))
+        QualifiedIdentifier::new(
+            module_ident!($module),
+            NamespacedIdentifier::Function(ident!($name)),
+        )
     };
 }
 
@@ -736,7 +754,7 @@ macro_rules! exp {
 
 macro_rules! import_all {
     ($module:ident) => {
-        Import::All { module: ident!($module) }
+        Import::All { module: module_ident!($module) }
     };
 }
 
@@ -744,7 +762,7 @@ macro_rules! import {
     ($module:ident, $item:ident) => {{
         let mut items: std::collections::HashSet<Identifier> = std::collections::HashSet::default();
         items.insert(ident!($item));
-        Import::Partial { module: ident!($module), items }
+        Import::Partial { module: module_ident!($module), items }
     }};
 }
 

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -37,6 +37,42 @@ macro_rules! module_ident {
             miden_diagnostics::SourceSpan::UNKNOWN,
         )
     };
+
+    ($($names:ident),+) => {
+        ModuleId::new(
+            vec![
+                $(
+                    Identifier::new(
+                        miden_diagnostics::SourceSpan::UNKNOWN,
+                        crate::Symbol::intern(stringify!($names)),
+                    )
+                ),+
+            ],
+            miden_diagnostics::SourceSpan::UNKNOWN,
+        )
+    };
+}
+
+macro_rules! import_all {
+    ($module:ident) => {
+        Import::All { module: module_ident!($module) }
+    };
+    ($($names:ident),+) => {
+        Import::All { module: module_ident!($($names),+) }
+    };
+}
+
+macro_rules! import {
+    ($module:ident, $item:ident) => {{
+        let mut items: std::collections::HashSet<Identifier> = std::collections::HashSet::default();
+        items.insert(ident!($item));
+        Import::Partial { module: module_ident!($module), items }
+    }};
+    (($($names:ident),+), $item:ident) => {{
+        let mut items: std::collections::HashSet<Identifier> = std::collections::HashSet::default();
+        items.insert(ident!($item));
+        Import::Partial { module: module_ident!($($names),+), items }
+    }};
 }
 
 macro_rules! ident {
@@ -67,6 +103,12 @@ macro_rules! function_ident {
     ($module:ident, $name:ident) => {
         QualifiedIdentifier::new(
             module_ident!($module),
+            NamespacedIdentifier::Function(ident!($name)),
+        )
+    };
+    (($($modules:ident),+), $name:ident) => {
+        QualifiedIdentifier::new(
+            module_ident!($($modules),+),
             NamespacedIdentifier::Function(ident!($name)),
         )
     };
@@ -491,7 +533,17 @@ macro_rules! call {
             args: vec![$($param),+],
             ty: None,
         })
-    }
+    };
+
+    (($($modules:ident),+) :: $callee:ident ($($param:expr),+)) => {
+        ScalarExpr::Call(Call {
+            span: miden_diagnostics::SourceSpan::UNKNOWN,
+            callee: ResolvableIdentifier::Resolved(function_ident!(($($modules),+), $callee)),
+            args: vec![$($param),+],
+            ty: None,
+        })
+    };
+
 }
 
 macro_rules! trace_segment {
@@ -750,20 +802,6 @@ macro_rules! exp {
             $rhs,
         ))
     };
-}
-
-macro_rules! import_all {
-    ($module:ident) => {
-        Import::All { module: module_ident!($module) }
-    };
-}
-
-macro_rules! import {
-    ($module:ident, $item:ident) => {{
-        let mut items: std::collections::HashSet<Identifier> = std::collections::HashSet::default();
-        items.insert(ident!($item));
-        Import::Partial { module: module_ident!($module), items }
-    }};
 }
 
 mod arithmetic_ops;

--- a/parser/src/parser/tests/modules.rs
+++ b/parser/src/parser/tests/modules.rs
@@ -10,8 +10,8 @@ fn use_declaration() {
 
     use foo::*;
     ";
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
-    expected.imports.insert(ident!(foo), import_all!(foo));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
+    expected.imports.insert(module_ident!(foo), import_all!(foo));
     ParseTest::new().expect_module_ast(source, expected);
 }
 
@@ -22,8 +22,8 @@ fn import_declaration() {
 
     use foo::bar;
     ";
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
-    expected.imports.insert(ident!(foo), import!(foo, bar));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
+    expected.imports.insert(module_ident!(foo), import!(foo, bar));
     ParseTest::new().expect_module_ast(source, expected);
 }
 

--- a/parser/src/parser/tests/modules.rs
+++ b/parser/src/parser/tests/modules.rs
@@ -9,9 +9,11 @@ fn use_declaration() {
     mod test
 
     use foo::*;
+    use bar::baz::*;
     ";
     let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.imports.insert(module_ident!(foo), import_all!(foo));
+    expected.imports.insert(module_ident!(bar, baz), import_all!(bar, baz));
     ParseTest::new().expect_module_ast(source, expected);
 }
 
@@ -21,9 +23,11 @@ fn import_declaration() {
     mod test
 
     use foo::bar;
+    use baz::bat::bot;
     ";
     let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.imports.insert(module_ident!(foo), import!(foo, bar));
+    expected.imports.insert(module_ident!(baz, bat), import!((baz, bat), bot));
     ParseTest::new().expect_module_ast(source, expected);
 }
 
@@ -59,6 +63,32 @@ fn modules_integration_test() {
     // defines an evaluator `other_constraint`, that evaluator is never called
     // so it is treated as dead code and stripped from the program
 
+    // ev is_binary([x]) {
+    //     enf x^2 = x;
+    // }
+    expected.evaluators.insert(
+        function_ident!((utils, binary), is_binary),
+        EvaluatorFunction::new(
+            SourceSpan::UNKNOWN,
+            ident!(is_binary),
+            vec![trace_segment!(TraceSegmentId::Main, "%0", [(x, 1)])],
+            vec![enforce!(eq!(exp!(access!(x, Type::Felt), int!(2)), access!(x, Type::Felt)))],
+        ),
+    );
+    // ev are_all_binary([c[3]]) {
+    //     enf is_binary([c]) for c in c;
+    // }
+    expected.evaluators.insert(
+        function_ident!((utils, binary), are_all_binary),
+        EvaluatorFunction::new(
+            SourceSpan::UNKNOWN,
+            ident!(are_all_binary),
+            vec![trace_segment!(TraceSegmentId::Main, "%1", [(c, 3)])],
+            vec![enforce_all!(
+                lc!(((c, expr!(access!(c, Type::Vector(3))))) => call!((utils, binary)::is_binary(vector!(access!(c, Type::Felt)))))
+            )],
+        ),
+    );
     // ev bar_constraint([clk]) {
     //    enf clk' = clk + k0 when k0
     // }
@@ -101,6 +131,9 @@ fn modules_integration_test() {
     expected
         .integrity_constraints
         .push(enforce!(call!(bar::bar_constraint(vector!(access!(clk, Type::Felt))))));
+    expected
+        .integrity_constraints
+        .push(enforce!(call!((utils, binary)::are_all_binary(vector!(access!(clk, Type::Felt), access!(fmp, Type::Felt), access!(ctx, Type::Felt))))));
     expected
         .boundary_constraints
         .push(enforce!(eq!(bounded_access!(clk, Boundary::First, Type::Felt), int!(0))));

--- a/parser/src/parser/tests/periodic_columns.rs
+++ b/parser/src/parser/tests/periodic_columns.rs
@@ -13,7 +13,7 @@ fn periodic_columns() {
         k1: [0, 0, 0, 0, 0, 0, 0, 1],
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     expected.periodic_columns.insert(
         ident!(k0),
         PeriodicColumn::new(SourceSpan::UNKNOWN, ident!(k0), vec![1, 0, 0, 0]),
@@ -32,7 +32,7 @@ fn empty_periodic_columns() {
 
     periodic_columns{}";
 
-    let expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     ParseTest::new().expect_module_ast(source, expected);
 }
 

--- a/parser/src/parser/tests/pub_inputs.rs
+++ b/parser/src/parser/tests/pub_inputs.rs
@@ -28,7 +28,7 @@ fn public_inputs_vec() {
         enf clk = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));
@@ -71,7 +71,7 @@ fn public_inputs_table() {
         enf clk = 0;
     }";
 
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1)]));

--- a/parser/src/parser/tests/selectors.rs
+++ b/parser/src/parser/tests/selectors.rs
@@ -26,7 +26,7 @@ fn single_selector() {
     integrity_constraints {
         enf clk' = clk when n1;
     }"#;
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected
         .trace_columns
         .push(trace_segment!(TraceSegmentId::Main, "$main", [(clk, 1), (n1, 1)]));
@@ -64,7 +64,7 @@ fn chained_selectors() {
     integrity_constraints {
         enf clk' = clk when (n1 & !n2) | !n3;
     }"#;
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -26,7 +26,7 @@ fn trace_columns() {
     integrity_constraints {
         enf clk = 0;
     }"#;
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",
@@ -65,7 +65,7 @@ fn trace_columns_groups() {
         enf a[1]' = 1;
         enf clk' = clk - 1;
     }"#;
-    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, module_ident!(test));
     expected.trace_columns.push(trace_segment!(
         TraceSegmentId::Main,
         "$main",

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -15,7 +15,7 @@ fn variables_with_and_operators() {
         enf clk' = clk + 1 when flag;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     // The constraint is converted into a comprehension constraint by the parser, which
     // involves generating an iterable with one element and giving it a generated binding
     let body = vec![let_!(flag = expr!(and!(access!(n1), not!(access!(n2)))) =>
@@ -43,7 +43,7 @@ fn variables_with_or_operators() {
         enf clk' = clk + 1 when flag;
     }";
 
-    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, module_ident!(test));
     let body = vec![let_!(flag = expr!(or!(access!(n1), not!(access!(n2, 1)))) =>
                    enforce_if!(match_arm!(eq!(access!(clk, 1), add!(access!(clk), int!(1))), access!(flag))))];
 

--- a/parser/src/sema/dependencies.rs
+++ b/parser/src/sema/dependencies.rs
@@ -6,12 +6,12 @@ use crate::ast::{ModuleId, QualifiedIdentifier};
 /// The dependency graph is used to construct the final [Program] representation,
 /// containing only those parts of the program which are referenced from the root
 /// module.
-pub type DependencyGraph = petgraph::graphmap::DiGraphMap<QualifiedIdentifier, DependencyType>;
+pub type DependencyGraph = petgraph::graph::DiGraph<QualifiedIdentifier, DependencyType>;
 
 /// Represents the graph of dependencies between modules, with no regard to what
 /// items in those modules are actually used. In other words, this graph tells us
 /// what modules depend on what other modules in the program.
-pub type ModuleGraph = petgraph::graphmap::DiGraphMap<ModuleId, ()>;
+pub type ModuleGraph = petgraph::graph::DiGraph<ModuleId, ()>;
 
 /// Represents the type of edges in the dependency graph
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/parser/src/sema/import_resolver.rs
+++ b/parser/src/sema/import_resolver.rs
@@ -47,25 +47,28 @@ impl VisitMut<SemanticAnalysisError> for ImportResolver<'_> {
         for import in imports.values_mut() {
             match import {
                 Import::All { module: from } => {
-                    let imported_from = match self
-                        .library
-                        .get(from)
-                        .ok_or(SemanticAnalysisError::ImportUndefined(*from))
-                    {
-                        Ok(value) => value,
-                        Err(err) => return ControlFlow::Break(err),
-                    };
-                    for export in imported_from.exports() {
-                        let name = export.name();
-                        let item = Identifier::new(from.span(), name.name());
-                        self.import(module, *from, item, export)?;
+                    let submodules = self.library.get_submodules_of(from);
+                    for submodule in submodules {
+                        let imported_from = match self
+                            .library
+                            .get(&submodule)
+                            .ok_or(SemanticAnalysisError::ImportUndefined(submodule.clone()))
+                        {
+                            Ok(value) => value,
+                            Err(err) => return ControlFlow::Break(err),
+                        };
+                        for export in imported_from.exports() {
+                            let name = export.name();
+                            let item = Identifier::new(from.span(), name.name());
+                            self.import(module, from.clone(), item, export)?;
+                        }
                     }
                 },
                 Import::Partial { module: from, items } => {
                     let imported_from = match self
                         .library
                         .get(from)
-                        .ok_or(SemanticAnalysisError::ImportUndefined(*from))
+                        .ok_or(SemanticAnalysisError::ImportUndefined(from.clone()))
                     {
                         Ok(value) => value,
                         Err(err) => return ControlFlow::Break(err),
@@ -77,7 +80,7 @@ impl VisitMut<SemanticAnalysisError> for ImportResolver<'_> {
                         // with the item in the set, not the span associated with the
                         // export.
                         if let Some(item) = items.get(&name) {
-                            self.import(module, *from, *item, export)?;
+                            self.import(module, from.clone(), *item, export)?;
                         }
                     }
                 },

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -64,7 +64,8 @@ pub struct SemanticAnalysis<'a> {
     diagnostics: &'a DiagnosticsHandler,
     program: &'a Program,
     library: &'a Library,
-    deps: &'a mut DependencyGraph,
+    deps_graph: &'a mut DependencyGraph,
+    deps_nodes: &'a mut BTreeMap<QualifiedIdentifier, petgraph::graph::NodeIndex>,
     imported: Imported,
     globals: HashMap<Identifier, BindingType>,
     constants: BTreeMap<Identifier, ConstantExpr>,
@@ -83,13 +84,15 @@ impl<'a> SemanticAnalysis<'a> {
         program: &'a Program,
         library: &'a Library,
         deps: &'a mut DependencyGraph,
+        deps_nodes: &'a mut BTreeMap<QualifiedIdentifier, petgraph::graph::NodeIndex>,
         imported: Imported,
     ) -> Self {
         Self {
             diagnostics,
             program,
             library,
-            deps,
+            deps_graph: deps,
+            deps_nodes,
             imported,
             globals: Default::default(),
             constants: Default::default(),
@@ -110,21 +113,23 @@ impl<'a> SemanticAnalysis<'a> {
         }
 
         // If this is the root module, we may have top-level dependencies
-        if module.name == self.program.name {
+        if module.path.0.item == vec![self.program.name] {
             // Update the dependency graph with the collected information
             //
             // We use a special node to represent the references which occur in
             // the top-level boundary_constraints and integrity_constraints sections
             let root_node = QualifiedIdentifier::new(
-                self.program.name,
+                ModuleId::new(vec![self.program.name], self.program.name.span()),
                 NamespacedIdentifier::Binding(Identifier::new(
                     SourceSpan::UNKNOWN,
                     Symbol::intern("$$root"),
                 )),
             );
-            for (referenced_item, ref_type) in self.referenced.iter() {
-                let referenced_item = self.deps.add_node(*referenced_item);
-                self.deps.add_edge(root_node, referenced_item, *ref_type);
+            let root_node_index = self.get_node_index_or_add(&root_node);
+            for (referenced_item, ref_type) in self.referenced.clone().iter() {
+                let referenced_item_node_index =
+                    self.get_node_index_or_add(&referenced_item.clone());
+                self.deps_graph.add_edge(root_node_index, referenced_item_node_index, *ref_type);
             }
         } else {
             // We should never have top-level dependencies here
@@ -140,7 +145,7 @@ impl<'a> SemanticAnalysis<'a> {
 
 impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
     fn visit_mut_module(&mut self, module: &mut Module) -> ControlFlow<SemanticAnalysisError> {
-        self.current_module = Some(module.name);
+        self.current_module = Some(module.path.clone());
 
         // Collect the values of all named constants that can be referenced in range declarations
         self.constants
@@ -366,12 +371,17 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
 
         // Update the dependency graph for this function
         let current_item = QualifiedIdentifier::new(
-            self.current_module.unwrap(),
+            self.current_module.clone().unwrap(),
             NamespacedIdentifier::Function(function.name),
         );
-        for (referenced_item, ref_type) in self.referenced.iter() {
-            let referenced_item = self.deps.add_node(*referenced_item);
-            self.deps.add_edge(current_item, referenced_item, *ref_type);
+        let current_item_node_index = self.get_node_index_or_add(&current_item);
+        for (referenced_item, ref_type) in self.referenced.clone().iter() {
+            let referenced_item_node_index = self.get_node_index_or_add(referenced_item);
+            self.deps_graph.add_edge(
+                current_item_node_index,
+                referenced_item_node_index,
+                *ref_type,
+            );
         }
 
         // Restore the original references metadata
@@ -409,12 +419,17 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
 
         // Update the dependency graph for this function
         let current_item = QualifiedIdentifier::new(
-            self.current_module.unwrap(),
+            self.current_module.clone().unwrap(),
             NamespacedIdentifier::Function(function.name),
         );
+        let current_item_node_index = self.deps_graph.add_node(current_item);
         for (referenced_item, ref_type) in self.referenced.iter() {
-            let referenced_item = self.deps.add_node(*referenced_item);
-            self.deps.add_edge(current_item, referenced_item, *ref_type);
+            let referenced_item_node_index = self.deps_graph.add_node(referenced_item.clone());
+            self.deps_graph.add_edge(
+                current_item_node_index,
+                referenced_item_node_index,
+                *ref_type,
+            );
         }
 
         // Restore the original references metadata
@@ -939,7 +954,7 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
             // Update the dependency graph
             if let Some(dep_type) = dep_type {
                 // If the item is already in the referenced set, it should have the same type
-                let prev = self.referenced.insert(*qid, dep_type);
+                let prev = self.referenced.insert(qid.clone(), dep_type);
                 if prev.is_some() {
                     assert_eq!(prev, Some(dep_type));
                 }
@@ -991,7 +1006,7 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         &mut self,
         expr: &mut ResolvableIdentifier,
     ) -> ControlFlow<SemanticAnalysisError> {
-        let current_module = self.current_module.unwrap();
+        let current_module = self.current_module.clone().unwrap();
         match expr {
             // If already resolved, and referencing a local variable, there is nothing to do
             ResolvableIdentifier::Local(_) => ControlFlow::Continue(()),
@@ -1036,7 +1051,7 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
                             // We use the program name to resolve the bus, as it is a globally
                             // defined item in the root module
                             *expr = ResolvableIdentifier::Resolved(QualifiedIdentifier::new(
-                                self.program.name,
+                                ModuleId::new(vec![self.program.name], self.program.name.span()),
                                 namespaced_id,
                             ));
                         },
@@ -1055,7 +1070,8 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
                 if let Some((imported_id, imported_from)) =
                     self.imported.get_key_value(&namespaced_id)
                 {
-                    let qualified_id = QualifiedIdentifier::new(*imported_from, *imported_id);
+                    let qualified_id =
+                        QualifiedIdentifier::new(imported_from.clone(), *imported_id);
                     *expr = ResolvableIdentifier::Resolved(qualified_id);
 
                     return ControlFlow::Continue(());
@@ -1590,7 +1606,7 @@ impl SemanticAnalysis<'_> {
                 // Check that the call references an evaluator
                 //
                 // If unresolved, we've already raised a diagnostic for the invalid call
-                match expr.callee {
+                match &expr.callee {
                     ResolvableIdentifier::Resolved(callee) => {
                         match callee.id() {
                             id @ NamespacedIdentifier::Function(_) => {
@@ -1642,7 +1658,7 @@ impl SemanticAnalysis<'_> {
                 // Check that the call references an evaluator
                 //
                 // If unresolved, we've already raised a diagnostic for the invalid call
-                match expr.bus {
+                match &expr.bus {
                     ResolvableIdentifier::Resolved(bus) => {
                         match bus.id() {
                             id @ NamespacedIdentifier::Binding(_) => {
@@ -1876,7 +1892,7 @@ impl SemanticAnalysis<'_> {
         &self,
         qid: &QualifiedIdentifier,
     ) -> Result<Span<BindingType>, InvalidAccessError> {
-        if qid.module == self.program.name {
+        if qid.module.0.item == vec![self.program.name] {
             // This is the root module, so the value will be in either locals or globals
             self.locals
                 .get_key_value(&qid.item)
@@ -1887,7 +1903,7 @@ impl SemanticAnalysis<'_> {
                         .map(|(k, v)| Span::new(k.span(), v.clone()))
                 })
                 .ok_or(InvalidAccessError::UndefinedVariable)
-        } else if qid.module == self.current_module.unwrap() {
+        } else if qid.module == self.current_module.clone().unwrap() {
             // This is a reference to a module-local declaration
             self.locals
                 .get_key_value(&qid.item)
@@ -1928,6 +1944,16 @@ impl SemanticAnalysis<'_> {
                 })
                 .ok_or(InvalidAccessError::UndefinedVariable)
         }
+    }
+
+    /// Adds the given module to the module graph if it does not already exist,
+    /// returning the corresponding node index.
+    fn get_node_index_or_add(&mut self, qid: &QualifiedIdentifier) -> petgraph::graph::NodeIndex {
+        self.deps_nodes.get(qid).cloned().unwrap_or_else(|| {
+            let index = self.deps_graph.add_node(qid.clone());
+            self.deps_nodes.insert(qid.clone(), index);
+            index
+        })
     }
 }
 

--- a/parser/src/transforms/constant_propagation.rs
+++ b/parser/src/transforms/constant_propagation.rs
@@ -64,7 +64,8 @@ impl<'a> ConstantPropagation<'a> {
         // Record all of the constant declarations
         for (name, constant) in program.constants.iter() {
             assert_eq!(
-                self.global.insert(*name, Span::new(constant.span(), constant.value.clone())),
+                self.global
+                    .insert(name.clone(), Span::new(constant.span(), constant.value.clone())),
                 None
             );
         }


### PR DESCRIPTION
## Describe your changes

This PR aims to close https://github.com/0xMiden/air-script/issues/488.
The main change is to handle `ModuleId` as a `Vec<Identifier>` instead of just `Identifier`. It allows to represent nested modules through there namespaced path (e.g. `utils::hash::my_hash_module` for the module that is in the file `utils/hash/my_hash_module.air`).

Main limitations:
1. Currently, imports are only allowed with full paths (relative to the importing module). As a result (with the example above), we can do `use utils::hash::my_hash_module::*` but the following are not supported:
  - `use utils::hash::*;`
  - `use utils::*;`
  - `use utils::hash;`
2. It is not possible to declare a module that is the *direct* parent of another. This means that we cannot declare the files `utils.air` or `utils/hash.air` in the example above. The hierarchy is only defined by the folder structure.

@Al-Kindi-0 would this be enough, or would you need one or both of these limitations lifted? I think the first one could be handled if needed, but I had some issues with import resolutions. For the second one, I'm not currently sure of the difficulty.