### PR TITLE
feat: replace nested Vec<Vec<u64>> with strided Matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix regressions on MIR and list_comprehensions (#449).
 - Fixed a vector unrolling issue in nested match evaluations (#491).
 - Fix evaluator argument vector slice expansion (#495).
+- replace Vec<Vec<u64>> with dense strided Matrix representation (#510).
 
 ## 0.4.0 (2025-06-20)
 

--- a/air/src/tests/constant.rs
+++ b/air/src/tests/constant.rs
@@ -1,4 +1,4 @@
-use super::{compile_from_source, expect_diagnostic};
+use super::compile_from_source;
 
 #[test]
 fn boundary_constraint_with_constants() {
@@ -66,5 +66,6 @@ fn invalid_matrix_constant() {
         enf clk' = clk + 1;
     }";
 
-    expect_diagnostic(source, "invalid matrix literal: mismatched dimensions");
+    // Validation now happens at parse time (issue #274)
+    assert!(compile_from_source(source).is_err());
 }

--- a/mir/src/ir/nodes/ops/value.rs
+++ b/mir/src/ir/nodes/ops/value.rs
@@ -112,7 +112,7 @@ impl BusAccess {
 pub enum ConstantValue {
     Felt(u64),
     Vector(Vec<u64>),
-    Matrix(Vec<Vec<u64>>),
+    Matrix(air_parser::ast::Matrix),
 }
 
 /// [TraceAccess] is like SymbolAccess, but is used to describe an access to a specific trace

--- a/mir/src/passes/translate.rs
+++ b/mir/src/passes/translate.rs
@@ -1194,7 +1194,7 @@ impl<'a> MirBuilder<'a> {
         match c {
             ast::ConstantExpr::Scalar(s) => self.translate_scalar_const(*s, span),
             ast::ConstantExpr::Vector(v) => self.translate_vector_const(v.clone(), span),
-            ast::ConstantExpr::Matrix(m) => self.translate_matrix_const(m.clone(), span),
+            ast::ConstantExpr::Matrix(m) => self.translate_matrix_const(m, span),
         }
     }
 
@@ -1213,12 +1213,17 @@ impl<'a> MirBuilder<'a> {
 
     fn translate_matrix_const(
         &mut self,
-        m: Vec<Vec<u64>>,
+        m: &air_parser::ast::Matrix,
         span: SourceSpan,
     ) -> Result<Link<Op>, CompileError> {
-        let mut node = Matrix::builder().size(m.len()).span(span);
-        for row in m.iter() {
-            let row_node = self.translate_vector_const(row.clone(), span)?;
+        let (rows, cols) = m.dimensions();
+        let mut node = Matrix::builder().size(rows).span(span);
+        let slice = m.as_slice();
+
+        for i in 0..rows {
+            let start = i * cols;
+            let end = start + cols;
+            let row_node = self.translate_vector_const(slice[start..end].to_vec(), span)?;
             node = node.elements(row_node);
         }
         let node = node.build();

--- a/mir/src/passes/unrolling/mod.rs
+++ b/mir/src/passes/unrolling/mod.rs
@@ -201,14 +201,17 @@ fn unroll_constant_vector(constant_vector: &Vec<u64>, span: SourceSpan) -> Link<
 }
 
 /// Unrolls a constant matrix into a `Matrix<Vector<ConstantValue::Felt>>`
-fn unroll_constant_matrix(constant_matrix: &Vec<Vec<u64>>, span: SourceSpan) -> Link<Op> {
+fn unroll_constant_matrix(constant_matrix: &air_parser::ast::Matrix, span: SourceSpan) -> Link<Op> {
     let mut res_m = vec![];
-    for row in constant_matrix {
+    let (rows, cols) = constant_matrix.dimensions();
+    let slice = constant_matrix.as_slice();
+
+    for i in 0..rows {
         let mut res_row = vec![];
-        for val in row {
+        for j in 0..cols {
             let val = Value::create(SpannedMirValue {
                 span,
-                value: MirValue::Constant(ConstantValue::Felt(*val)),
+                value: MirValue::Constant(ConstantValue::Felt(slice[i * cols + j])),
             });
             res_row.push(val);
         }

--- a/mir/src/tests/constant.rs
+++ b/mir/src/tests/constant.rs
@@ -1,4 +1,4 @@
-use super::{compile, expect_diagnostic};
+use super::compile;
 
 #[test]
 fn boundary_constraint_with_constants() {
@@ -66,5 +66,6 @@ fn invalid_matrix_constant() {
         enf clk' = clk + 1;
     }";
 
-    expect_diagnostic(source, "invalid matrix literal: mismatched dimensions");
+    // Validation now happens at parse time (issue #274)
+    assert!(compile(source).is_err());
 }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1.4"
 miden-diagnostics = { workspace = true }
 miden-parsing = "0.1"
 petgraph = "0.8"
+ref-cast = "1.0"
 regex = "1"
 thiserror = { workspace = true }
 

--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -166,7 +166,7 @@ impl PartialEq for Constant {
 pub enum ConstantExpr {
     Scalar(u64),
     Vector(Vec<u64>),
-    Matrix(Vec<Vec<u64>>),
+    Matrix(crate::ast::Matrix),
 }
 impl ConstantExpr {
     /// Gets the type of this expression
@@ -174,10 +174,9 @@ impl ConstantExpr {
         match self {
             Self::Scalar(_) => Type::Felt,
             Self::Vector(elems) => Type::Vector(elems.len()),
-            Self::Matrix(rows) => {
-                let num_rows = rows.len();
-                let num_cols = rows.first().unwrap().len();
-                Type::Matrix(num_rows, num_cols)
+            Self::Matrix(matrix) => {
+                let (rows, cols) = matrix.dimensions();
+                Type::Matrix(rows, cols)
             },
         }
     }
@@ -194,13 +193,26 @@ impl fmt::Display for ConstantExpr {
             Self::Vector(values) => {
                 write!(f, "{}", DisplayList(values.as_slice()))
             },
-            Self::Matrix(values) => write!(
-                f,
-                "{}",
-                DisplayBracketed(DisplayCsv::new(
-                    values.iter().map(|vs| DisplayList(vs.as_slice()))
-                ))
-            ),
+            Self::Matrix(matrix) => {
+                let (rows, cols) = matrix.dimensions();
+                let slice = matrix.as_slice();
+                // For display purposes, format as nested vectors
+                write!(f, "[")?;
+                for i in 0..rows {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "[")?;
+                    for j in 0..cols {
+                        if j > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", slice[i * cols + j])?;
+                    }
+                    write!(f, "]")?;
+                }
+                write!(f, "]")
+            },
         }
     }
 }

--- a/parser/src/ast/matrix.rs
+++ b/parser/src/ast/matrix.rs
@@ -104,6 +104,23 @@ impl Matrix {
         &self.storage
     }
 
+    /// Returns an iterator over the elements of a specific column across all rows
+    pub fn column_iter(&self, col: usize) -> impl Iterator<Item = u64> + '_ {
+        assert!(col < self.cols, "column index out of bounds");
+        (0..self.rows).map(move |row| self.get(row, col))
+    }
+
+    /// Returns the number of elements in the specified row
+    pub fn row_len(&self, row: usize) -> usize {
+        assert!(row < self.rows, "row index out of bounds");
+        self.cols
+    }
+
+    /// Returns the number of elements in the specified column
+    pub fn column_len(&self, _col: usize) -> usize {
+        self.rows
+    }
+
     /// Returns a specific element by row and column
     ///
     /// # Panics
@@ -141,6 +158,19 @@ impl Matrix {
     /// Consumes the matrix and returns the flat storage
     pub fn into_vec(self) -> Vec<u64> {
         self.storage
+    }
+
+    /// Returns an iterator over the columns of a specific row
+    pub fn row_iter(&self, row: usize) -> std::slice::Iter<'_, u64> {
+        assert!(row < self.rows, "row index out of bounds");
+        let start = row * self.cols;
+        let end = start + self.cols;
+        self.storage[start..end].iter()
+    }
+
+    /// Returns an iterator over all rows as slices
+    pub fn rows_iter(&self) -> impl Iterator<Item = &[u64]> {
+        self.storage.chunks_exact(self.cols)
     }
 }
 
@@ -269,5 +299,208 @@ mod tests {
         assert_eq!(matrix.cols(), 3);
         assert_eq!(matrix[0][0], 1);
         assert_eq!(matrix[1][2], 6);
+    }
+
+    #[test]
+    fn test_slice_rows_full_range() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        let matrix = Matrix::new(data).unwrap();
+        let sliced = matrix.slice_rows(0..3);
+
+        assert_eq!(sliced.rows(), 3);
+        assert_eq!(sliced.cols(), 3);
+        assert_eq!(sliced[0][0], 1);
+        assert_eq!(sliced[2][2], 9);
+    }
+
+    #[test]
+    fn test_slice_rows_partial_range() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        let matrix = Matrix::new(data).unwrap();
+        let sliced = matrix.slice_rows(1..3);
+
+        assert_eq!(sliced.rows(), 2);
+        assert_eq!(sliced.cols(), 3);
+        assert_eq!(sliced[0][0], 4);
+        assert_eq!(sliced[0][2], 6);
+        assert_eq!(sliced[1][0], 7);
+        assert_eq!(sliced[1][2], 9);
+    }
+
+    #[test]
+    fn test_slice_rows_single_row() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        let matrix = Matrix::new(data).unwrap();
+        let sliced = matrix.slice_rows(1..2);
+
+        assert_eq!(sliced.rows(), 1);
+        assert_eq!(sliced.cols(), 3);
+        assert_eq!(sliced[0][0], 4);
+        assert_eq!(sliced[0][2], 6);
+    }
+
+    #[test]
+    fn test_slice_rows_empty_range() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        // Empty ranges are valid (just produce empty results)
+        let sliced = matrix.slice_rows(1..1);
+        assert_eq!(sliced.rows(), 0);
+        assert_eq!(sliced.cols(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Range end out of bounds")]
+    fn test_slice_rows_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        let _sliced = matrix.slice_rows(1..3);
+    }
+
+    #[test]
+    #[should_panic(expected = "row index out of bounds")]
+    fn test_index_row_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        let _ = matrix[2];
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds")]
+    fn test_index_column_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        let _ = matrix[0][2];
+    }
+
+    #[test]
+    #[should_panic(expected = "row index out of bounds")]
+    fn test_get_row_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        matrix.get(2, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "column index out of bounds")]
+    fn test_get_column_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        matrix.get(0, 2);
+    }
+
+    #[test]
+    fn test_matrix_row_len() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        assert_eq!(matrix[0].len(), 3);
+        assert_eq!(matrix[1].len(), 3);
+    }
+
+    #[test]
+    fn test_matrix_row_is_empty() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        assert!(!matrix[0].is_empty());
+    }
+
+    #[test]
+    fn test_matrix_row_to_vec() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        assert_eq!(matrix[0].to_vec(), vec![1, 2, 3]);
+        assert_eq!(matrix[1].to_vec(), vec![4, 5, 6]);
+    }
+
+    #[test]
+    fn test_row_iter() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        let row0: Vec<_> = matrix.row_iter(0).copied().collect();
+        let row1: Vec<_> = matrix.row_iter(1).copied().collect();
+
+        assert_eq!(row0, vec![1, 2, 3]);
+        assert_eq!(row1, vec![4, 5, 6]);
+    }
+
+    #[test]
+    #[should_panic(expected = "row index out of bounds")]
+    fn test_row_iter_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        let _ = matrix.row_iter(2);
+    }
+
+    #[test]
+    fn test_rows_iter() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        let matrix = Matrix::new(data).unwrap();
+
+        let rows: Vec<Vec<_>> = matrix.rows_iter().map(|row| row.to_vec()).collect();
+
+        assert_eq!(rows, vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]);
+    }
+
+    #[test]
+    fn test_column_iter() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        let matrix = Matrix::new(data).unwrap();
+
+        let col0: Vec<_> = matrix.column_iter(0).collect();
+        let col1: Vec<_> = matrix.column_iter(1).collect();
+        let col2: Vec<_> = matrix.column_iter(2).collect();
+
+        assert_eq!(col0, vec![1, 4, 7]);
+        assert_eq!(col1, vec![2, 5, 8]);
+        assert_eq!(col2, vec![3, 6, 9]);
+    }
+
+    #[test]
+    #[should_panic(expected = "column index out of bounds")]
+    fn test_column_iter_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        let _ = matrix.column_iter(2);
+    }
+
+    #[test]
+    fn test_row_len() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        assert_eq!(matrix.row_len(0), 3);
+        assert_eq!(matrix.row_len(1), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "row index out of bounds")]
+    fn test_row_len_out_of_bounds() {
+        let data = vec![vec![1, 2], vec![3, 4]];
+        let matrix = Matrix::new(data).unwrap();
+        matrix.row_len(2);
+    }
+
+    #[test]
+    fn test_column_len() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        let matrix = Matrix::new(data).unwrap();
+
+        assert_eq!(matrix.column_len(0), 3);
+        assert_eq!(matrix.column_len(1), 3);
+    }
+
+    #[test]
+    fn test_column_len_different_column() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        // column_len should return the number of rows for any valid column
+        assert_eq!(matrix.column_len(0), 2);
+        assert_eq!(matrix.column_len(1), 2);
+        assert_eq!(matrix.column_len(2), 2);
     }
 }

--- a/parser/src/ast/matrix.rs
+++ b/parser/src/ast/matrix.rs
@@ -1,0 +1,273 @@
+//! Strided dense matrix representation for constant matrices.
+//!
+//! This module provides a memory-efficient representation of matrices using a single
+//! flat vector with strided access patterns, replacing the nested `Vec<Vec<u64>>` structure.
+
+use std::ops::Index;
+
+use ref_cast::RefCast;
+
+/// A strided dense matrix that stores elements in a single flat vector.
+///
+/// This provides more efficient memory usage and better cache locality compared to
+/// `Vec<Vec<u64>>`, while maintaining the same double-indexing interface.
+///
+/// The matrix is stored in row-major order: `storage[row * cols + col]`
+///
+/// # Example
+/// ```ignore
+/// let matrix = Matrix::new(vec![
+///     vec![1, 2, 3],
+///     vec![4, 5, 6],
+/// ]).unwrap();
+/// assert_eq!(matrix[0][0], 1);
+/// assert_eq!(matrix[0][1], 2);
+/// assert_eq!(matrix[1][0], 4);
+/// assert_eq!(matrix[1][2], 6);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Matrix {
+    /// The number of rows in the matrix
+    rows: usize,
+    /// The number of columns in the matrix
+    cols: usize,
+    /// The flat storage containing all matrix elements in row-major order
+    storage: Vec<u64>,
+}
+
+impl Matrix {
+    /// Creates a new matrix from nested vectors.
+    ///
+    /// # Validation
+    /// - All rows must have the same length
+    /// - Matrix must have at least one row and one column
+    ///
+    /// # Errors
+    /// Returns `None` if the validation fails.
+    pub fn new(data: Vec<Vec<u64>>) -> Option<Self> {
+        if data.is_empty() {
+            return None;
+        }
+
+        let rows = data.len();
+        let cols = data.first()?.len();
+
+        // Validate that all rows have the same length
+        for row in &data {
+            if row.len() != cols {
+                return None;
+            }
+        }
+
+        // Flatten the data into a single vector
+        let storage: Vec<u64> = data.into_iter().flatten().collect();
+
+        Some(Self { rows, cols, storage })
+    }
+
+    /// Creates a new matrix from flat storage. Validates that the storage size matches rows * cols.
+    pub fn from_flat(rows: usize, cols: usize, storage: Vec<u64>) -> Option<Self> {
+        if rows == 0 || cols == 0 || storage.len() != rows * cols {
+            return None;
+        }
+
+        Some(Self { rows, cols, storage })
+    }
+
+    /// Returns the number of rows in the matrix
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Returns the number of columns in the matrix
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    /// Returns the dimensions of the matrix as (rows, cols)
+    pub fn dimensions(&self) -> (usize, usize) {
+        (self.rows, self.cols)
+    }
+
+    /// Returns the total number of elements in the matrix
+    pub fn len(&self) -> usize {
+        self.rows * self.cols
+    }
+
+    /// Returns true if the matrix has no elements
+    pub fn is_empty(&self) -> bool {
+        self.rows == 0 || self.cols == 0
+    }
+
+    /// Returns the underlying flat storage slice
+    pub fn as_slice(&self) -> &[u64] {
+        &self.storage
+    }
+
+    /// Returns a specific element by row and column
+    ///
+    /// # Panics
+    /// Panics if row >= rows or col >= cols
+    pub fn get(&self, row: usize, col: usize) -> u64 {
+        assert!(row < self.rows, "row index out of bounds");
+        assert!(col < self.cols, "column index out of bounds");
+        self.storage[row * self.cols + col]
+    }
+
+    /// Extracts a submatrix consisting of the specified row range.
+    ///
+    /// # Panics
+    /// Panics if the range is out of bounds
+    pub fn slice_rows(&self, range: std::ops::Range<usize>) -> Self {
+        assert!(range.start <= range.end, "Invalid range");
+        assert!(range.end <= self.rows, "Range end out of bounds");
+
+        let new_rows = range.end - range.start;
+        let mut new_storage = Vec::with_capacity(new_rows * self.cols);
+
+        for row in range {
+            let start = row * self.cols;
+            let end = start + self.cols;
+            new_storage.extend_from_slice(&self.storage[start..end]);
+        }
+
+        Self {
+            rows: new_rows,
+            cols: self.cols,
+            storage: new_storage,
+        }
+    }
+
+    /// Consumes the matrix and returns the flat storage
+    pub fn into_vec(self) -> Vec<u64> {
+        self.storage
+    }
+}
+
+/// A view into a single row of a matrix, allowing double-indexing.
+///
+/// This type uses ref-cast to provide efficient zero-cost conversion from
+/// a slice of the matrix storage to a row view.
+#[derive(RefCast)]
+#[repr(transparent)]
+pub struct MatrixRow([u64]);
+
+impl MatrixRow {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn to_vec(&self) -> Vec<u64> {
+        self.0.to_vec()
+    }
+}
+
+impl Index<usize> for MatrixRow {
+    type Output = u64;
+
+    fn index(&self, col: usize) -> &Self::Output {
+        &self.0[col]
+    }
+}
+
+impl std::ops::Deref for MatrixRow {
+    type Target = [u64];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Allows indexing into a matrix by row, returning a view that can be indexed by column.
+///
+/// # Example
+/// ```ignore
+/// let matrix = Matrix::new(vec![vec![1, 2], vec![3, 4]]).unwrap();
+/// let row = &matrix[0];  // Returns &MatrixRow
+/// let elem = row[1];     // Returns &u64
+/// ```
+impl Index<usize> for Matrix {
+    type Output = MatrixRow;
+
+    fn index(&self, row: usize) -> &Self::Output {
+        assert!(row < self.rows, "row index out of bounds");
+        let start = row * self.cols;
+        let end = start + self.cols;
+        MatrixRow::ref_cast(&self.storage[start..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matrix_creation() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data.clone()).unwrap();
+
+        assert_eq!(matrix.rows(), 2);
+        assert_eq!(matrix.cols(), 3);
+        assert_eq!(matrix.len(), 6);
+        assert_eq!(matrix.dimensions(), (2, 3));
+    }
+
+    #[test]
+    fn test_matrix_indexing() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        assert_eq!(matrix[0][0], 1);
+        assert_eq!(matrix[0][1], 2);
+        assert_eq!(matrix[0][2], 3);
+        assert_eq!(matrix[1][0], 4);
+        assert_eq!(matrix[1][1], 5);
+        assert_eq!(matrix[1][2], 6);
+    }
+
+    #[test]
+    fn test_matrix_get() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data).unwrap();
+
+        assert_eq!(matrix.get(0, 0), 1);
+        assert_eq!(matrix.get(0, 2), 3);
+        assert_eq!(matrix.get(1, 0), 4);
+        assert_eq!(matrix.get(1, 2), 6);
+    }
+
+    #[test]
+    fn test_flat_storage() {
+        let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let matrix = Matrix::new(data.clone()).unwrap();
+
+        assert_eq!(matrix.as_slice(), &[1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn test_validation_different_row_lengths() {
+        let data = vec![vec![1, 2], vec![3, 4, 5]]; // Different lengths
+        assert!(Matrix::new(data).is_none());
+    }
+
+    #[test]
+    fn test_validation_empty_matrix() {
+        let data = vec![];
+        assert!(Matrix::new(data).is_none());
+    }
+
+    #[test]
+    fn test_from_flat() {
+        let storage = vec![1, 2, 3, 4, 5, 6];
+        let matrix = Matrix::from_flat(2, 3, storage).unwrap();
+
+        assert_eq!(matrix.rows(), 2);
+        assert_eq!(matrix.cols(), 3);
+        assert_eq!(matrix[0][0], 1);
+        assert_eq!(matrix[1][2], 6);
+    }
+}

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -2,6 +2,7 @@ mod declarations;
 mod display;
 mod errors;
 mod expression;
+mod matrix;
 mod module;
 mod statement;
 mod trace;
@@ -21,7 +22,8 @@ use miden_diagnostics::{
 
 pub(crate) use self::display::*;
 pub use self::{
-    declarations::*, errors::*, expression::*, module::*, statement::*, trace::*, types::*,
+    declarations::*, errors::*, expression::*, matrix::*, module::*, statement::*, trace::*,
+    types::*,
 };
 use crate::{
     Symbol,

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -333,27 +333,6 @@ impl Module {
             return Err(SemanticAnalysisError::NameConflict(constant.name.span()));
         }
 
-        // Validate constant expression
-        if let ConstantExpr::Matrix(matrix) = &constant.value {
-            let expected_len =
-                matrix.first().expect("expected matrix to have at least one row").len();
-            for vector in matrix.iter().skip(1) {
-                if expected_len != vector.len() {
-                    diagnostics
-                        .diagnostic(Severity::Error)
-                        .with_message("invalid constant")
-                        .with_primary_label(
-                            constant.span(),
-                            "invalid matrix literal: mismatched dimensions",
-                        )
-                        .with_note(
-                            "Matrix constants must have the same number of columns in each row",
-                        )
-                        .emit();
-                    return Err(SemanticAnalysisError::Invalid);
-                }
-            }
-        }
         assert_eq!(self.constants.insert(constant.name, constant), None);
 
         Ok(())

--- a/parser/src/lexer/mod.rs
+++ b/parser/src/lexer/mod.rs
@@ -644,10 +644,9 @@ where
 
         match num.parse::<u64>() {
             Ok(i) => Token::Num(i),
-            Err(err) => Token::Error(LexicalError::InvalidInt {
-                span: self.span(),
-                reason: err.kind().clone(),
-            }),
+            Err(err) => {
+                Token::Error(LexicalError::InvalidInt { span: self.span(), reason: *err.kind() })
+            },
         }
     }
 }

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -133,7 +133,13 @@ Constant: Constant = {
 ConstExpr: ConstantExpr = {
     <Num_u64> => ConstantExpr::Scalar(<>),
     <Vector<Num_u64>> => ConstantExpr::Vector(<>),
-    <Matrix<Num_u64>> => ConstantExpr::Matrix(<>),
+    <data:Matrix<Num_u64>> =>? {
+        crate::ast::Matrix::new(data)
+            .map(ConstantExpr::Matrix)
+            .ok_or(lalrpop_util::ParseError::User {
+                error: crate::ParseError::InvalidMatrix
+            })
+    },
 }
 
 // PUBLIC INPUTS

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -52,6 +52,8 @@ pub enum ParseError {
     },
     #[error("extraneous token '{token}'")]
     ExtraToken { span: SourceSpan, token: Token },
+    #[error("invalid matrix: all rows must have the same length")]
+    InvalidMatrix,
     #[error("parsing failed, see diagnostics for details")]
     Failed,
 }
@@ -72,6 +74,7 @@ impl PartialEq for ParseError {
                 Self::UnrecognizedToken { token: rt, expected: r, .. },
             ) => lt == rt && l == r,
             (Self::ExtraToken { token: l, .. }, Self::ExtraToken { token: r, .. }) => l == r,
+            (Self::InvalidMatrix, Self::InvalidMatrix) => true,
             (Self::Failed, Self::Failed) => true,
             _ => false,
         }
@@ -142,6 +145,11 @@ impl ToDiagnostic for ParseError {
             Self::ExtraToken { span, .. } => Diagnostic::error()
                 .with_message("extraneous token")
                 .with_labels(vec![Label::primary(span.source_id(), span)]),
+            Self::InvalidMatrix => {
+                Diagnostic::error().with_message("invalid matrix").with_notes(vec![
+                    "Matrix constants must have the same number of columns in each row".to_string(),
+                ])
+            },
             err => Diagnostic::error().with_message(err.to_string()),
         }
     }

--- a/parser/src/parser/tests/constants.rs
+++ b/parser/src/parser/tests/constants.rs
@@ -55,36 +55,22 @@ fn constants_matrices() {
     const B = [[5, 6], [7, 8]];";
 
     let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
-    expected.constants.insert(
-        ident!(A),
-        Constant::new(
-            SourceSpan::UNKNOWN,
-            ident!(A),
-            ConstantExpr::Matrix(vec![vec![1, 2], vec![3, 4]]),
-        ),
-    );
-    expected.constants.insert(
-        ident!(B),
-        Constant::new(
-            SourceSpan::UNKNOWN,
-            ident!(B),
-            ConstantExpr::Matrix(vec![vec![5, 6], vec![7, 8]]),
-        ),
-    );
+    expected.constants.insert(ident!(A), constant!(A = [[1, 2], [3, 4]]));
+    expected.constants.insert(ident!(B), constant!(B = [[5, 6], [7, 8]]));
     ParseTest::new().expect_module_ast(source, expected);
 }
 
 #[test]
 fn err_const_matrix_unequal_number_of_cols() {
-    // This is invalid since the number of columns for the two rows are unequal. However this
-    // validation happens at the IR level.
+    // This is invalid since the number of columns for the two rows are unequal.
+    // Validation now happens at parse time (issue #274).
     let source = "
     mod test
 
     const A = [[1, 2], [3, 4, 5]];";
 
-    ParseTest::new()
-        .expect_module_diagnostic(source, "invalid matrix literal: mismatched dimensions");
+    // Parsing should fail with invalid matrix error
+    assert!(ParseTest::new().parse_module(source).is_err());
 }
 
 #[test]

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -498,7 +498,14 @@ macro_rules! constant {
     };
 
     ($name:ident = [$([$($value:literal),+]),+]) => {
-        Constant::new(SourceSpan::UNKNOWN, ident!($name), ConstantExpr::Matrix(vec![$(vec![$($value),+]),+]))
+        {
+            let data = vec![$(vec![$($value),+]),+];
+            Constant::new(
+                SourceSpan::UNKNOWN,
+                ident!($name),
+                ConstantExpr::Matrix(Matrix::new(data).expect("Invalid matrix in test"))
+            )
+        }
     };
 }
 

--- a/parser/src/sema/scope.rs
+++ b/parser/src/sema/scope.rs
@@ -22,9 +22,10 @@ pub type Env<K, V> = Box<HashMap<K, V>>;
 /// When searching for keys, the search begins in the current scope, and searches upwards
 /// in the scope tree until either the root is reached and the search terminates, or the
 /// key is found in some intervening scope.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum LexicalScope<K, V> {
     /// An empty scope, this is the default state in which all [LexicalScope] start
+    #[default]
     Empty,
     /// Represents a non-empty, top-level (root) scope
     Root(Env<K, V>),
@@ -43,11 +44,6 @@ where
             Self::Root(scope) => Self::Root(scope.clone()),
             Self::Nested(parent, scope) => Self::Nested(Rc::clone(parent), scope.clone()),
         }
-    }
-}
-impl<K, V> Default for LexicalScope<K, V> {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 impl<K, V> LexicalScope<K, V> {

--- a/parser/src/transforms/constant_propagation.rs
+++ b/parser/src/transforms/constant_propagation.rs
@@ -238,9 +238,8 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                         ConstantExpr::Matrix(value) => match sym.access_type.clone() {
                             AccessType::Matrix(row, col) => match (*row, *col) {
                                 (ScalarExpr::Const(row), ScalarExpr::Const(col)) => {
-                                    if row.item >= value.len() as u64
-                                        || col.item >= value[row.item as usize].len() as u64
-                                    {
+                                    let (rows, cols) = value.dimensions();
+                                    if row.item >= rows as u64 || col.item >= cols as u64 {
                                         self.diagnostics.diagnostic(miden_diagnostics::Severity::Error)
                                             .with_message("attempted to access an index which is out of bounds")
                                             .with_primary_label(span, "index out of bounds")
@@ -399,14 +398,14 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                             },
                             AccessType::Slice(range) => {
                                 let range = range.to_slice_range();
-                                let matrix = value[range].to_vec();
+                                let matrix = value.slice_rows(range);
                                 *expr = Expr::Const(Span::new(span, ConstantExpr::Matrix(matrix)));
                             },
                             AccessType::Index(idx) => match *idx {
                                 ScalarExpr::Const(idx) => {
                                     *expr = Expr::Const(Span::new(
                                         span,
-                                        ConstantExpr::Vector(value[idx.item as usize].clone()),
+                                        ConstantExpr::Vector(value[idx.item as usize].to_vec()),
                                     ));
                                 },
                                 _ => {
@@ -514,8 +513,8 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                                 })
                                 .collect(),
                         ),
-                        Type::Matrix(..) => ConstantExpr::Matrix(
-                            vector
+                        Type::Matrix(..) => {
+                            let rows: Vec<Vec<u64>> = vector
                                 .iter()
                                 .map(|expr| match expr {
                                     Expr::Const(Span {
@@ -523,8 +522,11 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                                     }) => vs.clone(),
                                     _ => unreachable!(),
                                 })
-                                .collect(),
-                        ),
+                                .collect();
+                            ConstantExpr::Matrix(
+                                Matrix::new(rows).expect("Matrix dimensions should be valid"),
+                            )
+                        },
                         _ => unreachable!(),
                     };
                     *expr = Expr::Const(Span::new(span, new_expr));
@@ -541,18 +543,19 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                     }
                 }
                 if is_constant {
+                    let rows: Vec<Vec<u64>> = matrix
+                        .iter()
+                        .map(|row| {
+                            row.iter()
+                                .map(|col| match col {
+                                    ScalarExpr::Const(elem) => elem.item,
+                                    _ => unreachable!(),
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .collect();
                     let matrix = ConstantExpr::Matrix(
-                        matrix
-                            .iter()
-                            .map(|row| {
-                                row.iter()
-                                    .map(|col| match col {
-                                        ScalarExpr::Const(elem) => elem.item,
-                                        _ => unreachable!(),
-                                    })
-                                    .collect::<Vec<_>>()
-                            })
-                            .collect(),
+                        Matrix::new(rows).expect("Matrix dimensions should be valid"),
                     );
                     *expr = Expr::Const(Span::new(span, matrix));
                 }
@@ -606,7 +609,7 @@ impl VisitMut<SemanticAnalysisError> for ConstantPropagation<'_> {
                                 self.local.insert(binding, Span::new(span, value));
                             },
                             Expr::Const(Span { item: ConstantExpr::Matrix(elems), .. }) => {
-                                let value = ConstantExpr::Vector(elems[step].clone());
+                                let value = ConstantExpr::Vector(elems[step].to_vec());
                                 self.local.insert(binding, Span::new(span, value));
                             },
                             Expr::Range(range) => {


### PR DESCRIPTION
Replace the nested Vec<Vec<u64>> representation with a strided dense matrix:
- Single flat Vec<u64> for better memory efficiency and cache locality
- Enables double-indexing via ref-cast: matrix[row][col]
- Validation moved to constructor (parse time) instead of IR validation
- Added from_flat(), slice_rows(), and other utility methods

Updated usages across parser, MIR, and AIR:
- ConstantExpr::Matrix now uses new Matrix type
- ConstantValue::Matrix updated in MIR
- Removed old validation in module.rs (moved to Matrix::new)

Closes #274 