### PR TITLE
feat(air): add memoization to RandomInputs::eval

### DIFF
--- a/air/src/ir/random_inputs.rs
+++ b/air/src/ir/random_inputs.rs
@@ -33,6 +33,9 @@ pub struct RandomInputs {
 impl RandomInputs {
     /// Evaluates a given algebraic graph node at random points.
     pub fn eval(&mut self, graph: &AlgebraicGraph, node_index: &NodeIndex) -> QuadFelt {
+        if let Some(cached) = self.evals_map.get(node_index) {
+            return *cached;
+        }
         let op = graph.node(node_index).op();
         match op {
             Operation::Add(lhs, rhs) => {


### PR DESCRIPTION
## Describe your changes

This change introduces an early return from RandomInputs::eval when a node’s evaluation is already present in evals_map, which prevents repeated traversal of already-computed subgraphs during common subexpression elimination; the behavior remains deterministic because leaf randoms are already cached, and the graph is a DAG, so caching internal node results is semantically safe while considerably improving performance in the CSE evaluation loop.