### PR TITLE
Fix cross-module function calls

### DIFF
--- a/air-script/tests/cross_module_calls/cross_module_calls.air
+++ b/air-script/tests/cross_module_calls/cross_module_calls.air
@@ -1,0 +1,36 @@
+def CrossModuleTest
+
+# Import functions from test_utils module using cross-module syntax
+use test_utils::*;
+
+trace_columns {
+    main: [a, b, c, d],
+}
+
+public_inputs {
+    x: [1],
+}
+
+# Test function that uses cross-module calls
+fn test_cross_module_calls(x: felt, y: felt) -> felt {
+    # Direct calls to imported functions
+    let and_result = binary_and(x, y);
+    let or_result = binary_or(x, y);
+    let not_result = binary_not(x);
+
+    # Call function that returns array from test_utils
+    let flags = compute_flags(x, y);
+    let flag_a = flags[0];
+    let flag_b = flags[1];
+
+    return and_result + or_result + not_result + flag_a + flag_b;
+}
+
+boundary_constraints {
+    enf a.first = 0;
+}
+
+integrity_constraints {
+    # Use the cross-module function in constraints
+    enf a = test_cross_module_calls(b, c);
+}

--- a/air-script/tests/cross_module_calls/test_utils.air
+++ b/air-script/tests/cross_module_calls/test_utils.air
@@ -1,0 +1,20 @@
+# Utility module for cross-module testing
+mod test_utils
+
+fn binary_and(a: felt, b: felt) -> felt {
+    return a * b;
+}
+
+fn binary_or(a: felt, b: felt) -> felt {
+    return a + b - a * b;
+}
+
+fn binary_not(a: felt) -> felt {
+    return 1 - a;
+}
+
+fn compute_flags(x: felt, y: felt) -> felt[2] {
+    let flag_a = binary_and(x, y);
+    let flag_b = binary_or(x, y);
+    return [flag_a, flag_b];
+}

--- a/mir/src/passes/inlining.rs
+++ b/mir/src/passes/inlining.rs
@@ -532,7 +532,10 @@ fn extract_accessor(op: Link<Op>) -> Link<Op> {
     };
     let mut indexable = accessor.indexable.clone();
     match &accessor.access_type {
-        MirAccessType::Default => accessor.indexable.clone(),
+        MirAccessType::Default => {
+            // Recursively extract accessors from the indexable
+            extract_accessor(accessor.indexable.clone())
+        },
         MirAccessType::Index(idx_op) => {
             let idx = get_inner_const(idx_op)
                 .unwrap_or_else(|| panic!("expected constant index, got {:#?}", idx_op))

--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -253,12 +253,14 @@ impl PartialEq for Import {
 pub enum Export<'a> {
     Constant(&'a crate::ast::Constant),
     Evaluator(&'a EvaluatorFunction),
+    Function(&'a Function),
 }
 impl Export<'_> {
     pub fn name(&self) -> Identifier {
         match self {
             Self::Constant(item) => item.name,
             Self::Evaluator(item) => item.name,
+            Self::Function(item) => item.name,
         }
     }
 
@@ -270,6 +272,7 @@ impl Export<'_> {
         match self {
             Self::Constant(item) => Some(item.ty()),
             Self::Evaluator(_) => None,
+            Self::Function(item) => Some(item.return_type),
         }
     }
 }

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -635,7 +635,9 @@ impl Module {
         if id.is_uppercase() {
             self.constants.get(id).map(Export::Constant)
         } else {
-            self.evaluators.get(id).map(Export::Evaluator)
+            self.evaluators
+                .get(id)
+                .map(Export::Evaluator)
                 .or_else(|| self.functions.get(id).map(Export::Function))
         }
     }

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -627,6 +627,7 @@ impl Module {
             .values()
             .map(Export::Constant)
             .chain(self.evaluators.values().map(Export::Evaluator))
+            .chain(self.functions.values().map(Export::Function))
     }
 
     /// Get the export with the given identifier, if it can be found
@@ -635,6 +636,7 @@ impl Module {
             self.constants.get(id).map(Export::Constant)
         } else {
             self.evaluators.get(id).map(Export::Evaluator)
+                .or_else(|| self.functions.get(id).map(Export::Function))
         }
     }
 }

--- a/parser/src/sema/import_resolver.rs
+++ b/parser/src/sema/import_resolver.rs
@@ -105,6 +105,7 @@ impl ImportResolver<'_> {
         match export {
             Export::Constant(_) => self.import_constant(module, from, item),
             Export::Evaluator(_) => self.import_evaluator(module, from, item),
+            Export::Function(_) => self.import_function(module, from, item),
         }
     }
 
@@ -168,6 +169,55 @@ impl ImportResolver<'_> {
 
         let namespaced_name = NamespacedIdentifier::Function(item);
         match module.evaluators.get(&item) {
+            Some(exists) => ControlFlow::Break(SemanticAnalysisError::ImportConflict {
+                item,
+                prev: exists.name.span(),
+            }),
+            None => {
+                match self.imported.entry(namespaced_name) {
+                    Entry::Occupied(entry) => {
+                        let id = entry.key();
+                        let originally_imported_from = entry.get();
+                        if originally_imported_from == &from {
+                            // Warn about redundant import
+                            self.diagnostics
+                                .diagnostic(Severity::Warning)
+                                .with_message("redundant import")
+                                .with_primary_label(item.span(), "this import is unnecessary")
+                                .with_secondary_label(
+                                    id.span(),
+                                    "because it was already imported here",
+                                )
+                                .emit();
+                            ControlFlow::Continue(())
+                        } else {
+                            // Conflict is with another import, raise an error
+                            ControlFlow::Break(SemanticAnalysisError::ImportConflict {
+                                item,
+                                prev: id.span(),
+                            })
+                        }
+                    },
+                    Entry::Vacant(entry) => {
+                        entry.insert(from);
+                        ControlFlow::Continue(())
+                    },
+                }
+            },
+        }
+    }
+
+    /// Imports a function into the current module
+    fn import_function(
+        &mut self,
+        module: &mut Module,
+        from: ModuleId,
+        item: Identifier,
+    ) -> ControlFlow<SemanticAnalysisError> {
+        use std::collections::hash_map::Entry;
+
+        let namespaced_name = NamespacedIdentifier::Function(item);
+        match module.functions.get(&item) {
             Some(exists) => ControlFlow::Break(SemanticAnalysisError::ImportConflict {
                 item,
                 prev: exists.name.span(),

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -76,6 +76,9 @@ pub struct SemanticAnalysis<'a> {
     has_undefined_variables: bool,
     has_type_errors: bool,
     in_constraint_comprehension: bool,
+    /// Tracks the qualified identifier of the function or evaluator currently being analyzed.
+    /// This is used to build the dependency graph for function-to-function calls.
+    current_function: Option<QualifiedIdentifier>,
 }
 impl<'a> SemanticAnalysis<'a> {
     /// Create a new instance of the semantic analyzer
@@ -103,6 +106,7 @@ impl<'a> SemanticAnalysis<'a> {
             has_undefined_variables: false,
             has_type_errors: false,
             in_constraint_comprehension: false,
+            current_function: None,
         }
     }
 
@@ -338,6 +342,14 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         &mut self,
         function: &mut EvaluatorFunction,
     ) -> ControlFlow<SemanticAnalysisError> {
+        // Set the current function context for dependency tracking
+        let prev_function = self.current_function.clone();
+        let current_item = QualifiedIdentifier::new(
+            self.current_module.clone().unwrap(),
+            NamespacedIdentifier::Function(function.name),
+        );
+        self.current_function = Some(current_item.clone());
+
         // Only allow integrity constraints in this context
         self.constraint_mode = ConstraintMode::Integrity;
         // Start a new lexical scope
@@ -390,6 +402,8 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         self.locals.exit();
         // Disallow constraints
         self.constraint_mode = ConstraintMode::None;
+        // Restore previous function context
+        self.current_function = prev_function;
 
         ControlFlow::Continue(())
     }
@@ -398,6 +412,14 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         &mut self,
         function: &mut Function,
     ) -> ControlFlow<SemanticAnalysisError> {
+        // Set the current function context for dependency tracking
+        let prev_function = self.current_function.clone();
+        let current_item = QualifiedIdentifier::new(
+            self.current_module.clone().unwrap(),
+            NamespacedIdentifier::Function(function.name),
+        );
+        self.current_function = Some(current_item.clone());
+
         // constraints are not allowed in pure functions
         self.constraint_mode = ConstraintMode::None;
 
@@ -436,6 +458,8 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         self.referenced = referenced;
         // Restore the original lexical scope
         self.locals.exit();
+        // Restore previous function context
+        self.current_function = prev_function;
 
         ControlFlow::Continue(())
     }
@@ -695,10 +719,21 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
                             FunctionType::Evaluator(_) => DependencyType::Evaluator,
                             _ => DependencyType::Function,
                         };
+
+                        // If we're currently analyzing a function, add a direct dependency edge
+                        // from the current function to the called function. This ensures that
+                        // transitive dependencies across module boundaries are properly tracked.
+                        if let Some(caller) = self.current_function.clone() {
+                            let caller_node = self.get_node_index_or_add(&caller);
+                            let callee_node = self.get_node_index_or_add(&qid);
+                            self.deps_graph.add_edge(caller_node, callee_node, dependency_type);
+                        }
+
                         let prev = self.referenced.insert(qid, dependency_type);
                         if prev.is_some() {
                             assert_eq!(prev, Some(dependency_type));
                         }
+
                         // TODO: When we have non-evaluator functions, we must fetch the type in its
                         // signature here, and store it as the type of the
                         // Call expression
@@ -1939,6 +1974,17 @@ impl SemanticAnalysis<'_> {
                         Span::new(
                             e.span(),
                             BindingType::Function(FunctionType::Evaluator(e.params.clone())),
+                        )
+                    })
+                })
+                .or_else(|| {
+                    imported_from.functions.get(qid.as_ref()).map(|f| {
+                        Span::new(
+                            f.span(),
+                            BindingType::Function(FunctionType::Function(
+                                f.param_types(),
+                                f.return_type
+                            )),
                         )
                     })
                 })

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1983,7 +1983,7 @@ impl SemanticAnalysis<'_> {
                             f.span(),
                             BindingType::Function(FunctionType::Function(
                                 f.param_types(),
-                                f.return_type
+                                f.return_type,
                             )),
                         )
                     })


### PR DESCRIPTION
When functions in one module called functions from another module (e.g., `bitwise::compute_limb_and` calling `utils::binary_and`), these dependencies weren't tracked in the dependency graph.
  Root Cause

  Two issues were preventing proper handling of cross-module function calls:

  1. Missing dependency tracking: The semantic analysis only tracked root → function dependencies, not function → function dependencies across module boundaries.
  2. Incomplete accessor extraction: The MIR inlining pass's extract_accessor function didn't recursively handle Default accessors, causing failures when processing list comprehensions with function calls.

  The fix in this PR

  1. Semantic Analysis (parser/src/sema/semantic_analysis.rs)
  - Added current_function field to track which function/evaluator is being analyzed
  - Set this context when entering functions/evaluators and restore on exit
  - Added dependency edges in visit_mut_call to track function-to-function calls across modules

  2. Inlining Pass (mir/src/passes/inlining.rs)
  - Modified extract_accessor to recursively extract nested Default accessors instead of returning them directly
