### PR TITLE
fix: pin mdbook version to 0.4.48

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install mdbook and plugins
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook, mdbook-linkcheck, mdbook-alerts, mdbook-katex, mdbook-mermaid
+          tool: mdbook@0.4.48, mdbook-linkcheck, mdbook-alerts, mdbook-katex, mdbook-mermaid
 
       - name: Build book
         run: mdbook build docs/


### PR DESCRIPTION
Non-updated mdbook katex plugin caused issue with the CI in latest PRs.
