### PR TITLE
 fix inlining loop on cross imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
 - Fix regressions on MIR and list_comprehensions (#449).
 - Fixed a vector unrolling issue in nested match evaluations (#491).
 - Fix evaluator argument vector slice expansion (#495).
-- Support importing hierarchical modules (#507).
 - Fixed MIR's constant propagation to fold 0^0 to 1 (#509)
+- Support importing hierarchical modules (#507, #513, #514).
+- Fix MIR inlining loop on deeply nested calls (#524).
 
 ## 0.4.0 (2025-06-20)
 

--- a/air-script/tests/function_import/function_import.air
+++ b/air-script/tests/function_import/function_import.air
@@ -1,0 +1,22 @@
+def FunctionImportTest
+
+use utils::add;
+use utils::multiply;
+
+trace_columns {
+    main: [a, b, c],
+}
+
+public_inputs {
+    x: [1],
+}
+
+boundary_constraints {
+    enf a.first = 0;
+}
+
+integrity_constraints {
+    # Use imported pure functions
+    enf a = add(b, c);
+    enf b = multiply(a, c);
+}

--- a/air-script/tests/function_import/function_import.rs
+++ b/air-script/tests/function_import/function_import.rs
@@ -1,0 +1,98 @@
+use winter_air::{Air, AirContext, Assertion, AuxRandElements, EvaluationFrame, ProofOptions as WinterProofOptions, TransitionConstraintDegree, TraceInfo};
+use winter_math::fields::f64::BaseElement as Felt;
+use winter_math::{ExtensionOf, FieldElement, ToElements};
+use winter_utils::{ByteWriter, Serializable};
+
+pub struct PublicInputs {
+    x: [Felt; 1],
+}
+
+impl PublicInputs {
+    pub fn new(x: [Felt; 1]) -> Self {
+        Self { x }
+    }
+}
+
+impl Serializable for PublicInputs {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.x.write_into(target);
+    }
+}
+
+impl ToElements<Felt> for PublicInputs {
+    fn to_elements(&self) -> Vec<Felt> {
+        let mut elements = Vec::new();
+        elements.extend_from_slice(&self.x);
+        elements
+    }
+}
+
+pub struct FunctionImportTest {
+    context: AirContext<Felt>,
+    x: [Felt; 1],
+}
+
+impl FunctionImportTest {
+    pub fn last_step(&self) -> usize {
+        self.trace_length() - self.context().num_transition_exemptions()
+    }
+}
+
+impl Air for FunctionImportTest {
+    type BaseField = Felt;
+    type PublicInputs = PublicInputs;
+
+    fn context(&self) -> &AirContext<Felt> {
+        &self.context
+    }
+
+    fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
+        let main_degrees = vec![TransitionConstraintDegree::new(1), TransitionConstraintDegree::new(2)];
+        let aux_degrees = vec![];
+        let num_main_assertions = 1;
+        let num_aux_assertions = 0;
+
+        let context = AirContext::new_multi_segment(
+            trace_info,
+            main_degrees,
+            aux_degrees,
+            num_main_assertions,
+            num_aux_assertions,
+            options,
+        )
+        .set_num_transition_exemptions(2);
+        Self { context, x: public_inputs.x }
+    }
+
+    fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
+        vec![]
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Felt>> {
+        let mut result = Vec::new();
+        result.push(Assertion::single(0, 0, Felt::ZERO));
+        result
+    }
+
+    fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>> {
+        let mut result = Vec::new();
+        result
+    }
+
+    fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_current[0] - (main_current[1] + main_current[2]);
+        result[1] = main_current[1] - main_current[0] * main_current[2];
+    }
+
+    fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxRandElements<E>, result: &mut [E])
+    where F: FieldElement<BaseField = Felt>,
+          E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+    {
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+    }
+}

--- a/air-script/tests/function_import/mod.rs
+++ b/air-script/tests/function_import/mod.rs
@@ -1,0 +1,3 @@
+#[rustfmt::skip]
+#[allow(clippy::all)]
+mod function_import;

--- a/air-script/tests/function_import/utils.air
+++ b/air-script/tests/function_import/utils.air
@@ -1,0 +1,9 @@
+mod utils
+
+fn add(a: felt, b: felt) -> felt {
+    return a + b;
+}
+
+fn multiply(a: felt, b: felt) -> felt {
+    return a * b;
+}

--- a/air-script/tests/mod.rs
+++ b/air-script/tests/mod.rs
@@ -21,6 +21,8 @@ mod evaluators;
 #[allow(unused_variables, dead_code, unused_mut)]
 mod fibonacci;
 #[allow(unused_variables, dead_code, unused_mut)]
+mod function_import;
+#[allow(unused_variables, dead_code, unused_mut)]
 mod functions;
 #[allow(unused_variables, dead_code, unused_mut)]
 mod indexed_trace_access;

--- a/mir/Cargo.toml
+++ b/mir/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = { workspace = true }
 derive-ir = { package = "air-derive-ir", path = "./derive-ir", version = "0.5" }
 miden-core = { package = "miden-core", version = "0.13", default-features = false }
 miden-diagnostics = { workspace = true }
+ntest = "0.9.5"
 pretty_assertions = "1.4"
 rand = "0.9"
 thiserror = { workspace = true }

--- a/mir/src/passes/inlining.rs
+++ b/mir/src/passes/inlining.rs
@@ -532,7 +532,10 @@ fn extract_accessor(op: Link<Op>) -> Link<Op> {
     };
     let mut indexable = accessor.indexable.clone();
     match &accessor.access_type {
-        MirAccessType::Default => accessor.indexable.clone(),
+        MirAccessType::Default => {
+            // Recursively extract accessors from the indexable
+            extract_accessor(accessor.indexable.clone())
+        },
         MirAccessType::Index(idx_op) => {
             let idx = get_inner_const(idx_op)
                 .unwrap_or_else(|| panic!("expected constant index, got {:#?}", idx_op))

--- a/mir/src/passes/inlining.rs
+++ b/mir/src/passes/inlining.rs
@@ -476,7 +476,6 @@ impl Visitor for InliningSecondPass<'_> {
                 self.visit_call(graph, call_op.clone())?;
                 // NOTE: Once the call has been processed, we return early to avoid
                 // an infinite loop.
-                // modules.
                 // If there are nested calls, they will be handled via fixed-point
                 // compilation (see [<Inlining<'_> as Pass>::run]).
                 return Ok(());

--- a/mir/src/passes/inlining.rs
+++ b/mir/src/passes/inlining.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, ops::Deref};
+use std::{
+    collections::HashMap,
+    ops::Deref,
+};
 
 use air_pass::Pass;
 use miden_diagnostics::{DiagnosticsHandler, Severity, SourceSpan, Spanned};
@@ -141,6 +144,7 @@ pub struct InliningSecondPass<'a> {
     // HashMap<CaleePtr, (Callee, Vec<Call nodes where called>)>
     func_eval_nodes_where_called: HashMap<usize, (Link<Root>, Vec<Link<Op>>)>, // Op is a Call here
     had_calls: bool,
+    seen_root_call: bool,
 }
 
 impl<'a> InliningSecondPass<'a> {
@@ -158,6 +162,7 @@ impl<'a> InliningSecondPass<'a> {
             func_eval_nodes_where_called,
             func_eval_inlining_order,
             had_calls: false,
+            seen_root_call: false,
         }
     }
 }
@@ -315,7 +320,7 @@ impl Visitor for InliningSecondPass<'_> {
         let root_nodes_to_visit = self.root_nodes_to_visit(graph);
         self.had_calls = !root_nodes_to_visit.is_empty();
 
-        for root_node in root_nodes_to_visit {
+        for root_node in root_nodes_to_visit.iter() {
             let mut updated_op = None;
 
             if let Some(op) = root_node.as_op() {
@@ -346,9 +351,9 @@ impl Visitor for InliningSecondPass<'_> {
                 self.call_inlining_context = Some(context.clone());
                 self.nodes_to_replace.clear();
                 self.params_for_ref_node.clear();
+                self.seen_root_call = false;
 
                 self.scan_node(graph, root_node.clone())?;
-
                 while let Some(node) = self.work_stack().pop() {
                     self.visit_node(graph, node.clone())?;
                 }
@@ -429,7 +434,7 @@ impl Visitor for InliningSecondPass<'_> {
         if let Some(op) = node.clone().as_op() {
             // If we scan a `Call` node, we do not visit its children (the call's arguments)
             // TODO INLINING: Check whether this is the wanted behavior
-            if op.as_call().is_some() {
+            if op.as_call().is_some() && !self.seen_root_call {
                 return Ok(());
             };
             for child in node.children().borrow().iter() {
@@ -470,53 +475,56 @@ impl Visitor for InliningSecondPass<'_> {
             // First, check if it's a known `Call` to inline,
             // if so, set the context and scan its body
             if call_op.clone().as_call().is_some() {
-                self.visit_call(graph, call_op.clone())?;
-            } else {
-                // Else, we are currently visiting the body of a function or an evaluator of a call
-                // we want to inline We use our helper duplicate_node_or_replace to
-                // duplicate the body, while replacing the `Function` or `Evaluator` parameters with
-                // the `Call` arguments
-                if self.call_inlining_context.clone().unwrap().pure_function {
-                    duplicate_node_or_replace(
-                        &mut self.nodes_to_replace,
-                        call_op.clone(),
-                        self.call_inlining_context.clone().unwrap().arguments.borrow().clone(),
-                        self.call_inlining_context.clone().unwrap().ref_node,
-                        None,
-                        &mut self.params_for_ref_node,
-                    );
-                } else {
-                    // If we're inside the body of an evaluator, we first need to unpack the
-                    // arguments of the call to have a `Vector` of `TraceColumn`, and not
-                    // bindings to multiple columns
-                    let args =
-                        self.call_inlining_context.clone().unwrap().arguments.borrow().clone();
-
-                    let callee_params = self
-                        .call_inlining_context
-                        .clone()
-                        .unwrap()
-                        .ref_node
-                        .as_root()
-                        .unwrap()
-                        .as_evaluator()
-                        .unwrap()
-                        .parameters
-                        .clone();
-
-                    check_evaluator_argument_sizes(&args, callee_params, self.diagnostics)?;
-
-                    let args_unpacked = unpack_evaluator_arguments(&args);
-
-                    duplicate_node_or_replace(
-                        &mut self.nodes_to_replace,
-                        call_op.clone(),
-                        args_unpacked,
-                        self.call_inlining_context.clone().unwrap().ref_node,
-                        None,
-                        &mut self.params_for_ref_node,
-                    );
+                if !self.seen_root_call {
+                    self.seen_root_call = true;
+                    self.visit_call(graph, call_op.clone())?;
+                    return Ok(());
                 }
+            }
+
+            // Else, we are currently visiting the body of a function or an evaluator of a call
+            // we want to inline We use our helper duplicate_node_or_replace to
+            // duplicate the body, while replacing the `Function` or `Evaluator` parameters with
+            // the `Call` arguments
+            if self.call_inlining_context.clone().unwrap().pure_function {
+                duplicate_node_or_replace(
+                    &mut self.nodes_to_replace,
+                    call_op.clone(),
+                    self.call_inlining_context.clone().unwrap().arguments.borrow().clone(),
+                    self.call_inlining_context.clone().unwrap().ref_node,
+                    None,
+                    &mut self.params_for_ref_node,
+                );
+            } else {
+                // If we're inside the body of an evaluator, we first need to unpack the
+                // arguments of the call to have a `Vector` of `TraceColumn`, and not
+                // bindings to multiple columns
+                let args = self.call_inlining_context.clone().unwrap().arguments.borrow().clone();
+
+                let callee_params = self
+                    .call_inlining_context
+                    .clone()
+                    .unwrap()
+                    .ref_node
+                    .as_root()
+                    .unwrap()
+                    .as_evaluator()
+                    .unwrap()
+                    .parameters
+                    .clone();
+
+                check_evaluator_argument_sizes(&args, callee_params, self.diagnostics)?;
+
+                let args_unpacked = unpack_evaluator_arguments(&args);
+
+                duplicate_node_or_replace(
+                    &mut self.nodes_to_replace,
+                    call_op.clone(),
+                    args_unpacked,
+                    self.call_inlining_context.clone().unwrap().ref_node,
+                    None,
+                    &mut self.params_for_ref_node,
+                );
             }
         }
 

--- a/mir/src/passes/inlining.rs
+++ b/mir/src/passes/inlining.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    ops::Deref,
-};
+use std::{collections::HashMap, ops::Deref};
 
 use air_pass::Pass;
 use miden_diagnostics::{DiagnosticsHandler, Severity, SourceSpan, Spanned};

--- a/mir/src/passes/inlining.rs
+++ b/mir/src/passes/inlining.rs
@@ -471,16 +471,20 @@ impl Visitor for InliningSecondPass<'_> {
 
             // First, check if it's a known `Call` to inline,
             // if so, set the context and scan its body
-            if call_op.clone().as_call().is_some() {
-                if !self.seen_root_call {
-                    self.seen_root_call = true;
-                    self.visit_call(graph, call_op.clone())?;
-                    return Ok(());
-                }
+            if call_op.clone().as_call().is_some() && !self.seen_root_call {
+                self.seen_root_call = true;
+                self.visit_call(graph, call_op.clone())?;
+                // NOTE: Once the call has been processed, we return early to avoid
+                // an infinite loop.
+                // This can happen in some cases when you have nested calls accross
+                // modules.
+                // If there are nested calls, they will be handled via fixed-point
+                // compilation (see [<Inlining<'_> as Pass>::run]).
+                return Ok(());
             }
 
             // Else, we are currently visiting the body of a function or an evaluator of a call
-            // we want to inline We use our helper duplicate_node_or_replace to
+            // we want to inline. We use our helper duplicate_node_or_replace to
             // duplicate the body, while replacing the `Function` or `Evaluator` parameters with
             // the `Call` arguments
             if self.call_inlining_context.clone().unwrap().pure_function {

--- a/mir/src/passes/inlining.rs
+++ b/mir/src/passes/inlining.rs
@@ -476,7 +476,6 @@ impl Visitor for InliningSecondPass<'_> {
                 self.visit_call(graph, call_op.clone())?;
                 // NOTE: Once the call has been processed, we return early to avoid
                 // an infinite loop.
-                // This can happen in some cases when you have nested calls accross
                 // modules.
                 // If there are nested calls, they will be handled via fixed-point
                 // compilation (see [<Inlining<'_> as Pass>::run]).

--- a/mir/src/tests/ir/inlining2.rs
+++ b/mir/src/tests/ir/inlining2.rs
@@ -1,6 +1,10 @@
 use crate::tests::compile;
 #[cfg(test)]
 mod tests {
+    use ntest::timeout;
+
+    use crate::tests::Compiler;
+
     use super::*;
 
     //use crate::graph::pretty;
@@ -50,6 +54,91 @@ mod tests {
             let vec_sum = sum(vec);
 
             return a + vec_sum;
+        }
+        ";
+        let _mir = compile(code).unwrap();
+    }
+
+    #[test]
+    #[timeout(5000)]
+    fn inline_deeply_nested_calls() {
+        let code = "
+        def DeeplyNestedInliningLoopBug
+
+        trace_columns {
+            main: [a, b, c],
+        }
+
+        public_inputs {
+            x: [1],
+        }
+
+        # Utility functions (like utils module)
+        fn binary_and(a: felt, b: felt) -> felt {
+            return a * b;
+        }
+
+        fn binary_or(a: felt, b: felt) -> felt {
+            return a + b - a * b;
+        }
+
+        fn binary_not(a: felt) -> felt {
+            return 1 - a;
+        }
+
+        # Helper functions that use utilities (like flag functions)
+        fn flag_current_and_next(s_next: felt) -> felt {
+            return binary_not(s_next);
+        }
+
+        fn flag_last(s_next: felt) -> felt {
+            return s_next;
+        }
+
+        # Function that returns array and calls multiple helper functions (like section_flags)
+        fn section_flags(s_next: felt, s_start: felt, s_start_next: felt) -> felt[3] {
+            let f_next_flag = flag_current_and_next(s_next);
+            let f_last_flag = flag_last(s_next);
+
+            let f_start = s_start;
+            let f_next = binary_not(s_start_next);
+            let f_end = binary_or(binary_and(f_next_flag, s_start_next), f_last_flag);
+
+            return [f_start, f_next, f_end];
+        }
+
+        # Function that returns array (like block_flags)
+        fn block_flags(s_block: felt) -> felt[2] {
+            let f_read = binary_not(s_block);
+            let f_eval = s_block;
+
+            return [f_read, f_eval];
+        }
+
+        # Top-level evaluator that uses these functions (like section_block_flags_constraints)
+        fn complex_constraint(s: felt, sstart: felt, sstart_next: felt, sblock: felt) -> felt {
+            let flags = section_flags(s, sstart, sstart_next);
+            let f_start = flags[0];
+            let f_next = flags[1];
+            let f_end = flags[2];
+
+            let blocks = block_flags(sblock);
+            let blocks_next = block_flags(sblock);  # Simulate calling with next state
+            let f_read = blocks[0];
+            let f_eval = blocks[1];
+            let f_read_next = blocks_next[0];
+            let f_eval_next = blocks_next[1];
+
+            return f_start + f_next + f_end + f_read + f_eval + f_read_next + f_eval_next;
+        }
+
+        boundary_constraints {
+            enf a.first = 0;
+        }
+
+        integrity_constraints {
+            # Call complex constraint with deeply nested function calls
+            enf a = complex_constraint(b, c, b, c);
         }
         ";
         let _mir = compile(code).unwrap();

--- a/mir/src/tests/ir/inlining2.rs
+++ b/mir/src/tests/ir/inlining2.rs
@@ -3,8 +3,6 @@ use crate::tests::compile;
 mod tests {
     use ntest::timeout;
 
-    use crate::tests::Compiler;
-
     use super::*;
 
     //use crate::graph::pretty;

--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -251,12 +251,14 @@ impl PartialEq for Import {
 pub enum Export<'a> {
     Constant(&'a crate::ast::Constant),
     Evaluator(&'a EvaluatorFunction),
+    Function(&'a Function),
 }
 impl Export<'_> {
     pub fn name(&self) -> Identifier {
         match self {
             Self::Constant(item) => item.name,
             Self::Evaluator(item) => item.name,
+            Self::Function(item) => item.name,
         }
     }
 
@@ -268,6 +270,7 @@ impl Export<'_> {
         match self {
             Self::Constant(item) => Some(item.ty()),
             Self::Evaluator(_) => None,
+            Self::Function(item) => Some(item.return_type),
         }
     }
 }

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -635,7 +635,9 @@ impl Module {
         if id.is_uppercase() {
             self.constants.get(id).map(Export::Constant)
         } else {
-            self.evaluators.get(id).map(Export::Evaluator)
+            self.evaluators
+                .get(id)
+                .map(Export::Evaluator)
                 .or_else(|| self.functions.get(id).map(Export::Function))
         }
     }

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -627,6 +627,7 @@ impl Module {
             .values()
             .map(Export::Constant)
             .chain(self.evaluators.values().map(Export::Evaluator))
+            .chain(self.functions.values().map(Export::Function))
     }
 
     /// Get the export with the given identifier, if it can be found
@@ -635,6 +636,7 @@ impl Module {
             self.constants.get(id).map(Export::Constant)
         } else {
             self.evaluators.get(id).map(Export::Evaluator)
+                .or_else(|| self.functions.get(id).map(Export::Function))
         }
     }
 }

--- a/parser/src/sema/import_resolver.rs
+++ b/parser/src/sema/import_resolver.rs
@@ -105,6 +105,7 @@ impl ImportResolver<'_> {
         match export {
             Export::Constant(_) => self.import_constant(module, from, item),
             Export::Evaluator(_) => self.import_evaluator(module, from, item),
+            Export::Function(_) => self.import_function(module, from, item),
         }
     }
 
@@ -168,6 +169,55 @@ impl ImportResolver<'_> {
 
         let namespaced_name = NamespacedIdentifier::Function(item);
         match module.evaluators.get(&item) {
+            Some(exists) => ControlFlow::Break(SemanticAnalysisError::ImportConflict {
+                item,
+                prev: exists.name.span(),
+            }),
+            None => {
+                match self.imported.entry(namespaced_name) {
+                    Entry::Occupied(entry) => {
+                        let id = entry.key();
+                        let originally_imported_from = entry.get();
+                        if originally_imported_from == &from {
+                            // Warn about redundant import
+                            self.diagnostics
+                                .diagnostic(Severity::Warning)
+                                .with_message("redundant import")
+                                .with_primary_label(item.span(), "this import is unnecessary")
+                                .with_secondary_label(
+                                    id.span(),
+                                    "because it was already imported here",
+                                )
+                                .emit();
+                            ControlFlow::Continue(())
+                        } else {
+                            // Conflict is with another import, raise an error
+                            ControlFlow::Break(SemanticAnalysisError::ImportConflict {
+                                item,
+                                prev: id.span(),
+                            })
+                        }
+                    },
+                    Entry::Vacant(entry) => {
+                        entry.insert(from);
+                        ControlFlow::Continue(())
+                    },
+                }
+            },
+        }
+    }
+
+    /// Imports a function into the current module
+    fn import_function(
+        &mut self,
+        module: &mut Module,
+        from: ModuleId,
+        item: Identifier,
+    ) -> ControlFlow<SemanticAnalysisError> {
+        use std::collections::hash_map::Entry;
+
+        let namespaced_name = NamespacedIdentifier::Function(item);
+        match module.functions.get(&item) {
             Some(exists) => ControlFlow::Break(SemanticAnalysisError::ImportConflict {
                 item,
                 prev: exists.name.span(),

--- a/parser/src/sema/import_resolver.rs
+++ b/parser/src/sema/import_resolver.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ops::ControlFlow};
 use miden_diagnostics::{DiagnosticsHandler, Severity, Spanned};
 
 use crate::{
-    ast::{visit::VisitMut, *},
+    ast::{Export, visit::VisitMut, *},
     sema::SemanticAnalysisError,
 };
 
@@ -222,36 +222,31 @@ impl ImportResolver<'_> {
                 item,
                 prev: exists.name.span(),
             }),
-            None => {
-                match self.imported.entry(namespaced_name) {
-                    Entry::Occupied(entry) => {
-                        let id = entry.key();
-                        let originally_imported_from = entry.get();
-                        if originally_imported_from == &from {
-                            // Warn about redundant import
-                            self.diagnostics
-                                .diagnostic(Severity::Warning)
-                                .with_message("redundant import")
-                                .with_primary_label(item.span(), "this import is unnecessary")
-                                .with_secondary_label(
-                                    id.span(),
-                                    "because it was already imported here",
-                                )
-                                .emit();
-                            ControlFlow::Continue(())
-                        } else {
-                            // Conflict is with another import, raise an error
-                            ControlFlow::Break(SemanticAnalysisError::ImportConflict {
-                                item,
-                                prev: id.span(),
-                            })
-                        }
-                    },
-                    Entry::Vacant(entry) => {
-                        entry.insert(from);
+            None => match self.imported.entry(namespaced_name) {
+                Entry::Occupied(entry) => {
+                    let id = entry.key();
+                    let originally_imported_from = entry.get();
+                    if originally_imported_from == &from {
+                        // Warn about redundant import
+                        self.diagnostics
+                            .diagnostic(Severity::Warning)
+                            .with_message("redundant import")
+                            .with_primary_label(item.span(), "this import is unnecessary")
+                            .with_secondary_label(id.span(), "because it was already imported here")
+                            .emit();
                         ControlFlow::Continue(())
-                    },
-                }
+                    } else {
+                        // Conflict is with another import, raise an error
+                        ControlFlow::Break(SemanticAnalysisError::ImportConflict {
+                            item,
+                            prev: id.span(),
+                        })
+                    }
+                },
+                Entry::Vacant(entry) => {
+                    entry.insert(from);
+                    ControlFlow::Continue(())
+                },
             },
         }
     }

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -76,6 +76,9 @@ pub struct SemanticAnalysis<'a> {
     has_undefined_variables: bool,
     has_type_errors: bool,
     in_constraint_comprehension: bool,
+    /// Tracks the qualified identifier of the function or evaluator currently being analyzed.
+    /// This is used to build the dependency graph for function-to-function calls.
+    current_function: Option<QualifiedIdentifier>,
 }
 impl<'a> SemanticAnalysis<'a> {
     /// Create a new instance of the semantic analyzer
@@ -103,6 +106,7 @@ impl<'a> SemanticAnalysis<'a> {
             has_undefined_variables: false,
             has_type_errors: false,
             in_constraint_comprehension: false,
+            current_function: None,
         }
     }
 
@@ -338,6 +342,14 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         &mut self,
         function: &mut EvaluatorFunction,
     ) -> ControlFlow<SemanticAnalysisError> {
+        // Set the current function context for dependency tracking
+        let prev_function = self.current_function.clone();
+        let current_item = QualifiedIdentifier::new(
+            self.current_module.clone().unwrap(),
+            NamespacedIdentifier::Function(function.name),
+        );
+        self.current_function = Some(current_item.clone());
+
         // Only allow integrity constraints in this context
         self.constraint_mode = ConstraintMode::Integrity;
         // Start a new lexical scope
@@ -390,6 +402,8 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         self.locals.exit();
         // Disallow constraints
         self.constraint_mode = ConstraintMode::None;
+        // Restore previous function context
+        self.current_function = prev_function;
 
         ControlFlow::Continue(())
     }
@@ -398,6 +412,14 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         &mut self,
         function: &mut Function,
     ) -> ControlFlow<SemanticAnalysisError> {
+        // Set the current function context for dependency tracking
+        let prev_function = self.current_function.clone();
+        let current_item = QualifiedIdentifier::new(
+            self.current_module.clone().unwrap(),
+            NamespacedIdentifier::Function(function.name),
+        );
+        self.current_function = Some(current_item.clone());
+
         // constraints are not allowed in pure functions
         self.constraint_mode = ConstraintMode::None;
 
@@ -436,6 +458,8 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
         self.referenced = referenced;
         // Restore the original lexical scope
         self.locals.exit();
+        // Restore previous function context
+        self.current_function = prev_function;
 
         ControlFlow::Continue(())
     }
@@ -695,10 +719,21 @@ impl VisitMut<SemanticAnalysisError> for SemanticAnalysis<'_> {
                             FunctionType::Evaluator(_) => DependencyType::Evaluator,
                             _ => DependencyType::Function,
                         };
+
+                        // If we're currently analyzing a function, add a direct dependency edge
+                        // from the current function to the called function. This ensures that
+                        // transitive dependencies across module boundaries are properly tracked.
+                        if let Some(caller) = self.current_function.clone() {
+                            let caller_node = self.get_node_index_or_add(&caller);
+                            let callee_node = self.get_node_index_or_add(&qid);
+                            self.deps_graph.add_edge(caller_node, callee_node, dependency_type);
+                        }
+
                         let prev = self.referenced.insert(qid, dependency_type);
                         if prev.is_some() {
                             assert_eq!(prev, Some(dependency_type));
                         }
+
                         // TODO: When we have non-evaluator functions, we must fetch the type in its
                         // signature here, and store it as the type of the
                         // Call expression
@@ -1939,6 +1974,17 @@ impl SemanticAnalysis<'_> {
                         Span::new(
                             e.span(),
                             BindingType::Function(FunctionType::Evaluator(e.params.clone())),
+                        )
+                    })
+                })
+                .or_else(|| {
+                    imported_from.functions.get(qid.as_ref()).map(|f| {
+                        Span::new(
+                            f.span(),
+                            BindingType::Function(FunctionType::Function(
+                                f.param_types(),
+                                f.return_type
+                            )),
                         )
                     })
                 })

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1983,7 +1983,7 @@ impl SemanticAnalysis<'_> {
                             f.span(),
                             BindingType::Function(FunctionType::Function(
                                 f.param_types(),
-                                f.return_type
+                                f.return_type,
                             )),
                         )
                     })


### PR DESCRIPTION
## Describe your changes
Merges several pending PRs #513 #507 #514  into the branch al-constraints-air-only
Fixes an issue when inlining nested function calls accross modules.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
created from `al-constraints-air-only`
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
- [x] Updated `CHANGELOG.md`
