### PR TITLE
fix(mir): make BackLink parent removal precise

### DIFF
--- a/mir/src/ir/nodes/ops/accessor.rs
+++ b/mir/src/ir/nodes/ops/accessor.rs
@@ -70,6 +70,9 @@ impl Child for Accessor {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/add.rs
+++ b/mir/src/ir/nodes/ops/add.rs
@@ -33,10 +33,51 @@ impl Child for Add {
     fn get_parents(&self) -> Vec<BackLink<Self::Parent>> {
         self.parents.clone()
     }
+
     fn add_parent(&mut self, parent: Link<Self::Parent>) {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_remove_parent_removes_only_target() {
+        let span = SourceSpan::default();
+
+        let lhs: Link<Op> = Op::None(span).into();
+        let rhs: Link<Op> = Op::None(span).into();
+
+        let mut add = Add {
+            parents: Vec::new(),
+            lhs,
+            rhs,
+            _node: Singleton::default(),
+            _owner: Singleton::default(),
+            span,
+        };
+
+        let owner1: Link<Owner> = Owner::None(span).into();
+        let owner2: Link<Owner> = Owner::None(span).into();
+
+        add.add_parent(owner1.clone());
+        add.add_parent(owner2.clone());
+        assert_eq!(add.get_parents().len(), 2);
+
+        add.remove_parent(owner1.clone());
+
+        let parents = add.get_parents();
+        assert_eq!(parents.len(), 1);
+        let remaining =
+            parents[0].to_link().expect("BackLink<Owner> should upgrade to Link<Owner>");
+        assert_eq!(remaining, owner2);
     }
 }

--- a/mir/src/ir/nodes/ops/boundary.rs
+++ b/mir/src/ir/nodes/ops/boundary.rs
@@ -52,6 +52,9 @@ impl Child for Boundary {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/bus_op.rs
+++ b/mir/src/ir/nodes/ops/bus_op.rs
@@ -79,6 +79,9 @@ impl Child for BusOp {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/call.rs
+++ b/mir/src/ir/nodes/ops/call.rs
@@ -53,6 +53,9 @@ impl Child for Call {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/enf.rs
+++ b/mir/src/ir/nodes/ops/enf.rs
@@ -36,6 +36,9 @@ impl Child for Enf {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/exp.rs
+++ b/mir/src/ir/nodes/ops/exp.rs
@@ -39,6 +39,9 @@ impl Child for Exp {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/fold.rs
+++ b/mir/src/ir/nodes/ops/fold.rs
@@ -65,6 +65,9 @@ impl Child for Fold {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/for_op.rs
+++ b/mir/src/ir/nodes/ops/for_op.rs
@@ -62,6 +62,9 @@ impl Child for For {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/if_op.rs
+++ b/mir/src/ir/nodes/ops/if_op.rs
@@ -65,6 +65,9 @@ impl Child for If {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/matrix.rs
+++ b/mir/src/ir/nodes/ops/matrix.rs
@@ -45,6 +45,9 @@ impl Child for Matrix {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/mul.rs
+++ b/mir/src/ir/nodes/ops/mul.rs
@@ -37,6 +37,9 @@ impl Child for Mul {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/parameter.rs
+++ b/mir/src/ir/nodes/ops/parameter.rs
@@ -83,6 +83,9 @@ impl Child for Parameter {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/sub.rs
+++ b/mir/src/ir/nodes/ops/sub.rs
@@ -37,6 +37,9 @@ impl Child for Sub {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }

--- a/mir/src/ir/nodes/ops/value.rs
+++ b/mir/src/ir/nodes/ops/value.rs
@@ -50,7 +50,10 @@ impl Child for Value {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }
 

--- a/mir/src/ir/nodes/ops/vector.rs
+++ b/mir/src/ir/nodes/ops/vector.rs
@@ -44,6 +44,9 @@ impl Child for Vector {
         self.parents.push(parent.into());
     }
     fn remove_parent(&mut self, parent: Link<Self::Parent>) {
-        self.parents.retain(|p| *p != parent.clone().into());
+        self.parents.retain(|p| match p.to_link() {
+            Some(link) => link != parent,
+            None => true,
+        });
     }
 }


### PR DESCRIPTION
## Describe your changes


BackLink implements PartialEq as always true so that backlink fields are ignored in derived equality and hashing. However, 
remove_parent in MIR ops compared BackLink<Owner> values directly:
```rust
self.parents.retain(|p| *p != parent.clone().into());*
```

Because of the always-true PartialEq, this predicate was always false and effectively cleared the entire parents vector instead of removing only the requested parent.

This change updates all remove_parent implementations for ops that use parents: Vec<BackLink<Owner>> to compare against the upgraded Link<Owner> via to_link(), keeping BackLink’s structural Eq/Hash semantics intact while making parent removal semantically correct.
