### PR TITLE
Misc. updates and clarifying notes

### DIFF
--- a/constraints/ace.air
+++ b/constraints/ace.air
@@ -147,7 +147,12 @@ ev ace_chiplet_constraints_all_rows([s3, ace[16]]) {
     # - READ blocks: Define 2 nodes (id0, id1) with multiplicities (m0, m1)
     # - EVAL blocks: Consume 2 nodes (id1, id2), define 1 node (id0) with multiplicity m0
     #
-    # Each node is tracked with: (ctx, clk, id, v0, v1)
+    # Each node is tracked with: (clk, ctx, id, v0, v1)
+    #
+    # NOTE: The VM implementation forces the wiring bus accumulator to be 0 on ACE entry/exit,
+    # but Air-Script can only express `null` boundary constraints for buses. There is no way
+    # to encode these mid-trace boundary checks here.
+    # The sibling virtual table has the same limitation; its constraints are expected to be redesigned.
     ####################################################################################
 
     # READ block: Insert two nodes being loaded from memory
@@ -156,8 +161,8 @@ ev ace_chiplet_constraints_all_rows([s3, ace[16]]) {
     # Use conditional multiplicity: m * is_read_block (multiplicity if READ, 0 if EVAL)
     let m0_read = m0 * is_read_block;
     let m1_read = m1 * is_read_block;
-    bus_7_wiring_bus.insert(ctx, clk, id0, v0_0, v0_1) with m0_read;
-    bus_7_wiring_bus.insert(ctx, clk, id1, v1_0, v1_1) with m1_read;
+    bus_7_wiring_bus.insert(clk, ctx, id0, v0_0, v0_1) with m0_read;
+    bus_7_wiring_bus.insert(clk, ctx, id1, v1_0, v1_1) with m1_read;
 
     # EVAL block: Consume two input nodes, insert one result node
     # Consume input node 1: (id1, v1)
@@ -166,9 +171,9 @@ ev ace_chiplet_constraints_all_rows([s3, ace[16]]) {
     # Use conditional multiplicity: 1 * is_eval_block (consume if EVAL, 0 if READ)
     let consume = is_eval_block;
     let m0_eval = m0 * is_eval_block;
-    bus_7_wiring_bus.remove(ctx, clk, id1, v1_0, v1_1) with consume;
-    bus_7_wiring_bus.remove(ctx, clk, id2, v2_0, v2_1) with consume;
-    bus_7_wiring_bus.insert(ctx, clk, id0, v0_0, v0_1) with m0_eval;
+    bus_7_wiring_bus.remove(clk, ctx, id1, v1_0, v1_1) with consume;
+    bus_7_wiring_bus.remove(clk, ctx, id2, v2_0, v2_1) with consume;
+    bus_7_wiring_bus.insert(clk, ctx, id0, v0_0, v0_1) with m0_eval;
 }
 
 # Enforces that on the first row of ACE chiplet we should have sstart' = 1

--- a/constraints/decoder.air
+++ b/constraints/decoder.air
@@ -73,6 +73,7 @@ ev decoder([addr, b0, b1, b2, b3, b4, b5, b6, h0, h1, h2, h3, h4, h5, h6, h7, sp
     let fdyncall = flag_dyncall([b0, b1, b2, b3, b4, b5, b6], e0);
     let fsyscall = flag_syscall([b0, b1, b2, b3, b4, b5, b6], e1);
     let fevalcircuit = flag_evalcircuit([b0, b1, b2, b3, b4, b5, b6], e0);
+    let flogprecompile = flag_logprecompile([b0, b1, b2, b3, b4, b5, b6], e0);
     let fspan = flag_span([b0, b1, b2, b3, b4, b5, b6], e0);
     let frespan = flag_respan([b0, b1, b2, b3, b4, b5, b6], e1);
     let fend = flag_end([b0, b1, b2, b3, b4, b5, b6], e1);
@@ -183,9 +184,16 @@ ev decoder([addr, b0, b1, b2, b3, b4, b5, b6, h0, h1, h2, h3, h4, h5, h6, h7, sp
     bus_1_decoder_p2.insert(addr', h0, h1, h2, h3, 0, 0) when fdyncall;
     bus_1_decoder_p2.insert(addr', h0, h1, h2, h3, 0, 0) when fcall;
     bus_1_decoder_p2.insert(addr', h0, h1, h2, h3, 0, 0) when fsyscall;
+    bus_1_decoder_p2.insert(addr', h0, h1, h2, h3, 0, 0) when flogprecompile;
 
-    # END: Remove child hash (h6 indicates first child of JOIN)
-    bus_1_decoder_p2.remove(h1', h0', h1', h2', h3', h6, h5) when fend;
+    # END: Remove child hash.
+    # is_first_child = 1 when next op is NOT {END, REPEAT, HALT}
+    let fend_next = flag_end([b0', b1', b2', b3', b4', b5', b6'], e1');
+    let frepeat_next = flag_repeat([b0', b1', b2', b3', b4', b5', b6'], e1');
+    let fhalt_next = flag_halt([b0', b1', b2', b3', b4', b5', b6'], e1');
+    let is_first_child = 1 - (fend_next + frepeat_next + fhalt_next);
+    let is_loop_body = h4;
+    bus_1_decoder_p2.remove(addr', h0, h1, h2, h3, is_first_child, is_loop_body) when fend;
 
     ####################################################################################
     # BUS 2: OP GROUP TABLE (bus_2_decoder_p3)
@@ -525,10 +533,6 @@ fn flag_not(bits: felt[7]) -> felt {
     return (1 - bits[6]) * (1 - bits[5]) * (1 - bits[4]) * (1 - bits[3]) * bits[2] * (1 - bits[1]) * bits[0];
 }
 
-fn flag_fmpadd(bits: felt[7]) -> felt {
-    return (1 - bits[6]) * (1 - bits[5]) * (1 - bits[4]) * (1 - bits[3]) * bits[2] * bits[1] * (1 - bits[0]);
-}
-
 fn flag_mload(bits: felt[7]) -> felt {
     return (1 - bits[6]) * (1 - bits[5]) * (1 - bits[4]) * (1 - bits[3]) * bits[2] * bits[1] * bits[0];
 }
@@ -697,10 +701,6 @@ fn flag_mstorew(bits: felt[7]) -> felt {
     return (1 - bits[6]) * bits[5] * (1 - bits[4]) * bits[3] * bits[2] * bits[1] * (1 - bits[0]);
 }
 
-fn flag_fmpupdate(bits: felt[7]) -> felt {
-    return (1 - bits[6]) * bits[5] * (1 - bits[4]) * bits[3] * bits[2] * bits[1] * bits[0];
-}
-
 ##########################################################################################
 # RIGHT STACK SHIFT OPERATIONS (011 group) - 16 operations
 ##########################################################################################
@@ -847,11 +847,11 @@ fn flag_dyn(bits: felt[7], e0: felt) -> felt {
     return e0 * f_x1000(bits[3], bits[2], bits[1], bits[0]);
 }
 
-fn flag_hornerext(bits: felt[7], e0: felt) -> felt {
+fn flag_hornerbase(bits: felt[7], e0: felt) -> felt {
     return e0 * f_x1001(bits[3], bits[2], bits[1], bits[0]);
 }
 
-fn flag_op101_1010(bits: felt[7], e0: felt) -> felt {
+fn flag_hornerext(bits: felt[7], e0: felt) -> felt {
     return e0 * f_x1010(bits[3], bits[2], bits[1], bits[0]);
 }
 
@@ -867,7 +867,7 @@ fn flag_evalcircuit(bits: felt[7], e0: felt) -> felt {
     return e0 * f_x1101(bits[3], bits[2], bits[1], bits[0]);
 }
 
-fn flag_op101_1110(bits: felt[7], e0: felt) -> felt {
+fn flag_logprecompile(bits: felt[7], e0: felt) -> felt {
     return e0 * f_x1110(bits[3], bits[2], bits[1], bits[0]);
 }
 
@@ -884,7 +884,7 @@ fn flag_mrupdate(bits: felt[7], e1: felt) -> felt {
     return e1 * (1 - bits[4]) * (1 - bits[3]) * (1 - bits[2]);  # 110_0000, last 2 bits forced to 0
 }
 
-fn flag_hornerbase(bits: felt[7], e1: felt) -> felt {
+fn flag_cryptostream(bits: felt[7], e1: felt) -> felt {
     return e1 * (1 - bits[4]) * bits[3] * (1 - bits[2]);        # 110_0100, last 2 bits forced to 0
 }
 
@@ -1060,7 +1060,7 @@ fn compute_all_operation_flags(bits: felt[7], e0: felt, e1: felt) -> felt[96] {
         f_000_val * f_x0011_val,    # op_inv
         f_000_val * f_x0100_val,    # op_incr
         f_000_val * f_x0101_val,    # op_not
-        f_000_val * f_x0110_val,    # op_fmpadd
+        0,                          # unused
         f_000_val * f_x0111_val,    # op_mload
         f_000_val * f_x1000_val,    # op_swap
         f_000_val * f_x1001_val,    # op_caller
@@ -1105,7 +1105,7 @@ fn compute_all_operation_flags(bits: felt[7], e0: felt, e1: felt) -> felt[96] {
         f_010_val * f_x1100_val,    # op_mloadw
         f_010_val * f_x1101_val,    # op_mstore
         f_010_val * f_x1110_val,    # op_mstorew
-        f_010_val * f_x1111_val,    # op_fmpupdate
+        0,                          # unused
 
         # Right stack shift operations (011 group) - 16 operations
         f_011_val * f_x0000_val,    # op_pad
@@ -1145,17 +1145,17 @@ fn compute_all_operation_flags(bits: felt[7], e0: felt, e1: felt) -> felt[96] {
         e0 * f_x0110_val,    # op_span
         e0 * f_x0111_val,    # op_join
         e0 * f_x1000_val,    # op_dyn
-        e0 * f_x1001_val,    # op_hornerext
-        e0 * f_x1010_val,    # op_101_1010 (unused)
+        e0 * f_x1001_val,    # op_hornerbase
+        e0 * f_x1010_val,    # op_hornerext
         e0 * f_x1011_val,    # op_push (high-degree)
         e0 * f_x1100_val,    # op_dyncall
         e0 * f_x1101_val,    # op_evalcircuit
-        e0 * f_x1110_val,    # op_101_1110 (unused)
+        e0 * f_x1110_val,    # op_logprecompile
         e0 * f_x1111_val,    # op_101_1111 (unused)
 
         # Very high-degree operations (110/111 groups) - 8 operations
         e1 * (1 - bits[4]) * (1 - bits[3]) * (1 - bits[2]),    # op_mrupdate (110_0000)
-        e1 * (1 - bits[4]) * bits[3] * (1 - bits[2]),          # op_hornerbase (110_0100)
+        e1 * (1 - bits[4]) * bits[3] * (1 - bits[2]),          # op_cryptostream (110_0100)
         e1 * bits[4] * (1 - bits[3]) * (1 - bits[2]),          # op_syscall (110_1000)
         e1 * bits[4] * bits[3] * (1 - bits[2]),                # op_call (110_1100)
         e1 * bits[4] * (1 - bits[3]) * (1 - bits[2]),          # op_end (111_0000)
@@ -1188,7 +1188,9 @@ fn flag_shr(bits: felt[7], e0: felt, e1: felt) -> felt {
     return fshr_base + fu32split + fpush;
 }
 
-# Left-Shift Flag: fshl = (1−b6)⋅b5⋅(1−b4) + fadd3_madd + fsplit_loop + frepeat + fend⋅h5 (degree 5)
+# Left-Shift Flag: fshl = (1−b6)⋅b5⋅(1−b4) + fadd3_madd + fsplit_loop + fdyn + frepeat + fend⋅h5 (degree 5)
+# Note: DYNCALL performs a left shift but is excluded here because its overflow handling
+# uses the decoder hasher state instead of the standard stack overflow columns.
 fn flag_shl(bits: felt[7], h5: felt, e0: felt, e1: felt) -> felt {
     # Base left shift pattern: (1−b6)⋅b5⋅(1−b4)
     let fshl_base = (1 - bits[6]) * bits[5] * (1 - bits[4]);
@@ -1199,6 +1201,9 @@ fn flag_shl(bits: felt[7], h5: felt, e0: felt, e1: felt) -> felt {
     # fsplit_loop: SPLIT and LOOP operations (101 group with specific pattern)
     let fsplit_loop = e0 * (1 - bits[3]) * bits[2] * (1 - bits[1]);
 
+    # fdyn: DYN operation (opcode 88: 101_1000)
+    let fdyn = flag_dyn(bits, e0);
+
     # frepeat: REPEAT operation (opcode 116: 111_0100)
     let frepeat = e1 * bits[4] * (1 - bits[3]) * bits[2];
 
@@ -1206,10 +1211,10 @@ fn flag_shl(bits: felt[7], h5: felt, e0: felt, e1: felt) -> felt {
     let fend = e1 * bits[4] * (1 - bits[3]) * (1 - bits[2]);
     let fend_h5 = fend * h5;
 
-    return fshl_base + fadd3_madd + fsplit_loop + frepeat + fend_h5;
+    return fshl_base + fadd3_madd + fsplit_loop + fdyn + frepeat + fend_h5;
 }
 
-# Control Flow Flag: fctrl = fspan,join,split,loop + fend,repeat,respan,halt + fdyn + fcall + fsyscall (degree 5)
+# Control Flow Flag: fctrl = fspan,join,split,loop + fend,repeat,respan,halt + fdyn + fdyncall + fcall + fsyscall (degree 5)
 fn flag_ctrl(bits: felt[7], e0: felt, e1: felt) -> felt {
     # fspan,join,split,loop: High-degree control flow ops with pattern e0⋅(1−b3)⋅b2
     let fspan_join_split_loop = e0 * (1 - bits[3]) * bits[2];
@@ -1220,13 +1225,16 @@ fn flag_ctrl(bits: felt[7], e0: felt, e1: felt) -> felt {
     # fdyn: DYN operation (opcode 88: 101_1000)
     let fdyn = e0 * bits[3] * (1 - bits[2]) * (1 - bits[1]) * (1 - bits[0]);
 
+    # fdyncall: DYNCALL operation (opcode 92: 101_1100)
+    let fdyncall = e0 * f_x1100(bits[3], bits[2], bits[1], bits[0]);
+
     # fcall: CALL operation (opcode 108: 110_1100)
     let fcall = e1 * bits[4] * bits[3] * (1 - bits[2]);
 
     # fsyscall: SYSCALL operation (opcode 104: 110_1000)
     let fsyscall = e1 * bits[4] * (1 - bits[3]) * (1 - bits[2]);
 
-    return fspan_join_split_loop + fend_repeat_respan_halt + fdyn + fcall + fsyscall;
+    return fspan_join_split_loop + fend_repeat_respan_halt + fdyn + fdyncall + fcall + fsyscall;
 }
 
 # Immediate Value Flag: fimm = fpush (degree 5)

--- a/constraints/memory.air
+++ b/constraints/memory.air
@@ -24,6 +24,11 @@
 #
 # STATUS: Fully implemented with chiplets bus integration
 #
+# NOTE: The spec currently omits explicit range checks to ensure addresses fit within the
+# intended 32-bit space and that word accesses satisfy the divisibility-by-4 requirement
+# (addr = 4 * w_addr + idx0 + 2 * idx1 with idx0/idx1 in {0,1}). These checks should be added
+# in a follow-up pass.
+#
 # REFERENCES:
 # - Memory Design: https://0xmiden.github.io/miden-vm/design/chiplets/memory.html
 ##########################################################################################
@@ -153,11 +158,15 @@ ev memory_chiplet_constraints_all_rows_except_last([memory[15]]) {
     let f3_bus = idx1 * idx0;
     let element_value = f0_bus * v0 + f1_bus * v1 + f2_bus * v2 + f3_bus * v3;
 
+    # Compute element address: addr + idx0 + 2 * idx1.
+    # For word accesses, idx bits are 0, so this equals the word address.
+    let element_addr = addr + idx0 + 2 * idx1;
+
     # Remove responses from bus when operations occur
-    bus_6_chiplets_bus.remove(MEMREADWORD, ctx, addr, clk, v0, v1, v2, v3) when is_word_read;
-    bus_6_chiplets_bus.remove(MEMWRITEWORD, ctx, addr, clk, v0, v1, v2, v3) when is_word_write;
-    bus_6_chiplets_bus.remove(MEMREADELEMENT, ctx, addr, clk, element_value) when is_element_read;
-    bus_6_chiplets_bus.remove(MEMWRITEELEMENT, ctx, addr, clk, element_value) when is_element_write;
+    bus_6_chiplets_bus.remove(MEMREADWORD, ctx, element_addr, clk, v0, v1, v2, v3) when is_word_read;
+    bus_6_chiplets_bus.remove(MEMWRITEWORD, ctx, element_addr, clk, v0, v1, v2, v3) when is_word_write;
+    bus_6_chiplets_bus.remove(MEMREADELEMENT, ctx, element_addr, clk, element_value) when is_element_read;
+    bus_6_chiplets_bus.remove(MEMWRITEELEMENT, ctx, element_addr, clk, element_value) when is_element_write;
 }
 
 ##########################################################################################

--- a/constraints/miden_vm.air
+++ b/constraints/miden_vm.air
@@ -142,16 +142,18 @@ boundary_constraints {
     ####################################################################################
 
     # Decoder buses
-    enf bus_0_decoder_p1.first = unconstrained;
-    enf bus_0_decoder_p1.last = unconstrained;
+    enf bus_0_decoder_p1.first = null;
+    enf bus_0_decoder_p1.last = null;
+    # Block hash table (p2) boundaries will be handled via aux_finals once buses are
+    # uniformized to start at 1/0, so we leave both ends unconstrained here.
     enf bus_1_decoder_p2.first = unconstrained;
     enf bus_1_decoder_p2.last = unconstrained;
-    enf bus_2_decoder_p3.first = unconstrained;
-    enf bus_2_decoder_p3.last = unconstrained;
+    enf bus_2_decoder_p3.first = null;
+    enf bus_2_decoder_p3.last = null;
 
     # Stack overflow table
-    enf bus_3_stack_p1.first = unconstrained;
-    enf bus_3_stack_p1.last = unconstrained;
+    enf bus_3_stack_p1.first = null;
+    enf bus_3_stack_p1.last = null;
 
     # Range checker bus
     enf bus_4_range_checker.first = null;
@@ -162,8 +164,9 @@ boundary_constraints {
     enf bus_5_v_table.last = unconstrained;
 
     # Chiplets communication bus
-    # Initial state contains kernel procedure digests against which the program was compiled
-    enf bus_6_chiplets_bus.first = kernel_digests;
+    # Bus starts empty; kernel digests are folded in via kernel ROM responses.
+    # Final value is checked via aux_finals in the VM, so we leave last unconstrained here.
+    enf bus_6_chiplets_bus.first = null;
     enf bus_6_chiplets_bus.last = unconstrained;
 
     # ACE wiring bus

--- a/constraints/stack.air
+++ b/constraints/stack.air
@@ -76,6 +76,24 @@ ev stack_general_constraints([s15, b0, b1, h0, decoder_b0, decoder_b1, decoder_b
     # 4. LEFT SHIFT ZERO INSERTION CONSTRAINT
     enf left_shift_zero_insertion([s15, b0, h0, decoder_b0, decoder_b1, decoder_b2, decoder_b3, decoder_b4, decoder_b5, decoder_b6,
                                   decoder_h5, decoder_e0, decoder_e1]);
+
+    # 5. STACK OVERFLOW BUS CONSTRAINTS
+    #
+    # Tracks rows pushed to and popped from the overflow table:
+    # - Right shift: push (clk, s15, b1)
+    # - Left shift: pop (b1, s15', b1') when overflow is non-empty
+    # - DYNCALL: pop (b1, s15', h5) when overflow is non-empty
+    let depth_excess = b0 - 16;
+    let fov = depth_excess * h0;
+
+    let op_bits = [decoder_b0, decoder_b1, decoder_b2, decoder_b3, decoder_b4, decoder_b5, decoder_b6];
+    let fshr = flag_shr(op_bits, decoder_e0, decoder_e1);
+    let fshl = flag_shl(op_bits, decoder_h5, decoder_e0, decoder_e1);
+    let fdyncall = flag_dyncall(op_bits, decoder_e0);
+
+    bus_3_stack_p1.insert(system_clk, s15, b1) when fshr;
+    bus_3_stack_p1.remove(b1, s15', b1') when (fshl * fov);
+    bus_3_stack_p1.remove(b1, s15', decoder_h5) when (fdyncall * fov);
 }
 
 # Stack overflow flag constraint
@@ -153,6 +171,10 @@ ev right_shift_b1_constraint([b1, decoder_b0, decoder_b1, decoder_b2, decoder_b3
 # OPERATION-SPECIFIC STACK CONSTRAINTS
 ##########################################################################################
 
+# Stack-manipulation constraints mirror the implementation grouping:
+# PAD/DUP*/CLK, SWAP, MOVUP2..MOVUP8, MOVDN2..MOVDN8, SWAPW/SWAPW2/SWAPW3/SWAPDW, CSWAP/CSWAPW.
+# The per-op constraints below are listed in opcode order but cover the same groups.
+
 # Applies the appropriate operation-specific constraints based on active operation flags
 ev stack_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15,
                                stack_b0, stack_b1, decoder_b0, decoder_b1, decoder_b2, decoder_b3, decoder_b4, decoder_b5, decoder_b6,
@@ -177,7 +199,6 @@ ev stack_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
     let is_inv = flag_inv(op_bits);             # Opcode 3
     let is_incr = flag_incr(op_bits);           # Opcode 4
     let is_not = flag_not(op_bits);             # Opcode 5
-    let is_fmpadd = flag_fmpadd(op_bits);       # Opcode 6
     let is_mload = flag_mload(op_bits);         # Opcode 7
     let is_swap = flag_swap(op_bits);           # Opcode 8
     let is_caller = flag_caller(op_bits);       # Opcode 9
@@ -220,7 +241,6 @@ ev stack_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
     let is_mloadw = flag_mloadw(op_bits);       # Opcode 44
     let is_mstore = flag_mstore(op_bits);       # Opcode 45
     let is_mstorew = flag_mstorew(op_bits);     # Opcode 46
-    let is_fmpupdate = flag_fmpupdate(op_bits);   # Opcode 47
 
     # Group 3: Right stack shift operations - ordered by Miden VM specification (opcodes 48-63)
     let is_pad = flag_pad(op_bits);             # Opcode 48
@@ -258,14 +278,16 @@ ev stack_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
     let is_split = flag_split(op_bits, decoder_e0);  # Opcode 84 (101_0100)
     let is_loop = flag_loop(op_bits, decoder_e0);  # Opcode 85 (101_0101)
     let is_dyn = flag_dyn(op_bits, decoder_e0);  # Opcode 88 (101_1000)
-    let is_hornerext = flag_hornerext(op_bits, decoder_e0);  # Opcode 89 (101_1001)
+    let is_hornerext = flag_hornerext(op_bits, decoder_e0);  # Opcode 90 (101_1010)
     let is_push = flag_push(op_bits, decoder_e0);  # Opcode 91 (101_1011)
     let is_dyncall = flag_dyncall(op_bits, decoder_e0);  # Opcode 92 (101_1100)
     let is_evalcircuit = flag_evalcircuit(op_bits, decoder_e0);  # Opcode 93 (101_1101)
+    let is_logprecompile = flag_logprecompile(op_bits, decoder_e0);  # Opcode 94 (101_1110)
 
     # Group 5: Very high-degree operations (110 group) - requires e1 for degree reduction
     let is_mrupdate = flag_mrupdate(op_bits, decoder_e1);  # Opcode 96 (110_0000)
-    let is_hornerbase = flag_hornerbase(op_bits, decoder_e1);  # Opcode 100 (110_0100)
+    let is_cryptostream = flag_cryptostream(op_bits, decoder_e1);  # Opcode 100 (110_0100)
+    let is_hornerbase = flag_hornerbase(op_bits, decoder_e0);  # Opcode 89 (101_1001)
     let is_syscall = flag_syscall(op_bits, decoder_e1);  # Opcode 104 (110_1000)
     let is_call = flag_call(op_bits, decoder_e1);  # Opcode 108 (110_1100)
 
@@ -277,7 +299,6 @@ ev stack_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
         case is_inv: inv_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]),           # 3
         case is_incr: incr_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]),         # 4
         case is_not: not_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]),           # 5
-        case is_fmpadd: fmpadd_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_fmp]), # 6
         case is_mload: mload_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_ctx, system_clk]),       # 7
         case is_swap: swap_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]),         # 8
         case is_caller: caller_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_fn_hash_0, system_fn_hash_1, system_fn_hash_2, system_fn_hash_3]),     # 9
@@ -320,7 +341,6 @@ ev stack_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
         case is_mloadw: mloadw_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_ctx, system_clk]),   # 44
         case is_mstore: mstore_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_ctx, system_clk]),   # 45
         case is_mstorew: mstorew_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_ctx, system_clk]), # 46
-        case is_fmpupdate: fmpupdate_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_fmp]), # 47
 
         # Right stack shift operations - ordered by Miden VM specification (opcodes 48-63)
         case is_pad: pad_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]),       # 48
@@ -358,14 +378,17 @@ ev stack_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
         case is_split: split_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]), # 84
         case is_loop: loop_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]), # 85
         case is_dyn: dyn_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]), # 88
-        case is_hornerext: hornerext_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, decoder_h0, decoder_h1, decoder_h2, decoder_h3, decoder_h4, decoder_h5]), # 89
+        case is_hornerext: hornerext_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, decoder_h0, decoder_h1, decoder_h2, decoder_h3, decoder_h4, decoder_h5]), # 90
         case is_push: push_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]), # 91
         case is_dyncall: dyncall_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, stack_b0, stack_b1]), # 92
         case is_evalcircuit: evalcircuit_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]), # 93
+        case is_logprecompile: logprecompile_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15,
+                                                                    decoder_h0, decoder_h1, decoder_h2, decoder_h3, decoder_h4]), # 94
 
         # Very high-degree operations (110 group)
         case is_mrupdate: mrupdate_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]), # 96
-        case is_hornerbase: hornerbase_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, decoder_h0, decoder_h1, decoder_h2, decoder_h3, decoder_h4, decoder_h5]), # 100
+        case is_cryptostream: cryptostream_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_ctx, system_clk]), # 100
+        case is_hornerbase: hornerbase_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, decoder_h0, decoder_h1, decoder_h2, decoder_h3, decoder_h4, decoder_h5]), # 89
         case is_syscall: syscall_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, stack_b0, stack_b1]), # 104
         case is_call: call_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, stack_b0, stack_b1]), # 108
     };
@@ -475,6 +498,29 @@ ev mstream_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s
     enf s12' = s12 + 8;
     # Positions 13-15: Unchanged
     enf s13' = s13; enf s14' = s14; enf s15' = s15;
+}
+
+# CRYPTOSTREAM operation: Read two words, add rate, write ciphertext, update rate.
+# Stack layout: [R0(4), R1(4), C(4), src_ptr, dst_ptr, ...]
+# After: [CT0(4), CT1(4), C(4), src_ptr+8, dst_ptr+8, ...]
+ev cryptostream_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, system_ctx, system_clk]) {
+    # Positions 8-11: Unchanged (capacity preserved)
+    enf s8' = s8; enf s9' = s9; enf s10' = s10; enf s11' = s11;
+    # Positions 12-13: Source/destination pointers incremented by 8 (2 words)
+    enf s12' = s12 + 8;
+    enf s13' = s13 + 8;
+    # Positions 14-15: Unchanged
+    enf s14' = s14; enf s15' = s15;
+
+    # Plaintext = ciphertext - rate (element-wise)
+    let p0 = s0' - s0; let p1 = s1' - s1; let p2 = s2' - s2; let p3 = s3' - s3;
+    let p4 = s4' - s4; let p5 = s5' - s5; let p6 = s6' - s6; let p7 = s7' - s7;
+
+    # Read two words from source and write two words to destination.
+    bus_6_chiplets_bus.insert(MEMREADWORD, system_ctx, s12, system_clk, p0, p1, p2, p3) when 1;
+    bus_6_chiplets_bus.insert(MEMREADWORD, system_ctx, s12 + 4, system_clk, p4, p5, p6, p7) when 1;
+    bus_6_chiplets_bus.insert(MEMWRITEWORD, system_ctx, s13, system_clk, s0', s1', s2', s3') when 1;
+    bus_6_chiplets_bus.insert(MEMWRITEWORD, system_ctx, s13 + 4, system_clk, s4', s5', s6', s7') when 1;
 }
 
 # PUSH operation: Push an immediate value onto the stack (high-degree operation)
@@ -618,6 +664,21 @@ ev evalcircuit_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s1
     # All positions unchanged (circuit evaluation handled by ACE chiplet)
     enf s0' = s0; enf s1' = s1; enf s2' = s2; enf s3' = s3; enf s4' = s4; enf s5' = s5; enf s6' = s6; enf s7' = s7;
     enf s8' = s8; enf s9' = s9; enf s10' = s10; enf s11' = s11; enf s12' = s12; enf s13' = s13; enf s14' = s14; enf s15' = s15;
+}
+
+# LOG_PRECOMPILE operation: Apply Poseidon2 to [COMM, TAG, CAP_PREV] and update stack.
+# Stack behavior: [COMM, TAG, PAD, ...] -> [R0, R1, CAP_NEXT, ...]
+ev logprecompile_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, h0, h1, h2, h3, h4]) {
+    # Positions 0-11: overwritten by hasher outputs (unconstrained in stack module)
+    # Positions 12-15: unchanged
+    enf s12' = s12; enf s13' = s13; enf s14' = s14; enf s15' = s15;
+
+    # CAP_PREV comes from decoder helper registers h1..h4; CAP_NEXT is s8'..s11'.
+    bus_5_v_table.remove(LOGPRECOMPILE, h1, h2, h3, h4) when 1;
+    bus_5_v_table.insert(LOGPRECOMPILE, s8', s9', s10', s11') when 1;
+
+    # Link the output state to the hasher chiplet bus.
+    bus_6_chiplets_bus.insert(HASHERRETURNSTATE, s0', s1', s2', s3', s4', s5', s6', s7', s8', s9', s10', s11') when 1;
 }
 
 # DUP operation: Duplicate top stack element
@@ -1169,8 +1230,8 @@ ev u32div_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s1
     # Constraint 2: Quotient bound s1 - s1' = 2^16·h1 + h0 (ensures c ≤ a)
     enf s1 - s1' = h1 * 2^16 + h0;
 
-    # Constraint 3: Remainder bound s0 - s0' - 1 = 2^16·h2 + h3 (ensures d < b)
-    enf s0 - s0' - 1 = h2 * 2^16 + h3;
+    # Constraint 3: Remainder bound s0 - s0' - 1 = 2^16·h3 + h2 (ensures d < b)
+    enf s0 - s0' - 1 = h3 * 2^16 + h2;
 
     # Positions 2-15: Unchanged
     enf s2' = s2; enf s3' = s3; enf s4' = s4; enf s5' = s5; enf s6' = s6; enf s7' = s7; enf s8' = s8; enf s9' = s9;
@@ -1542,28 +1603,6 @@ ev frie2f4_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s
 
     # Constraint 9.2: Preserve folded position
     enf f_pos_out = f_pos;  # degree 1
-}
-
-# FMPADD operation: Add FMP value to top stack element (no stack depth change)
-# Stack behavior: [a, ...] -> [a + fmp, ...] (no depth change)
-ev fmpadd_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, fmp]) {
-    # Position 0: Gets s0 + fmp (adds FMP value to top element)
-    enf s0' = s0 + fmp;
-    # Positions 1-15: Unchanged (all other elements stay in place)
-    enf s1' = s1; enf s2' = s2; enf s3' = s3; enf s4' = s4; enf s5' = s5; enf s6' = s6; enf s7' = s7; enf s8' = s8;
-    enf s9' = s9; enf s10' = s10; enf s11' = s11; enf s12' = s12; enf s13' = s13; enf s14' = s14; enf s15' = s15;
-}
-
-# FMPUPDATE operation: Add top stack value to FMP and remove it (left shift - decreases depth by 1)
-# Stack behavior: [value, ...] -> [...] updates FMP = FMP + value
-ev fmpupdate_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, fmp]) {
-    # FMP system state constraint: new_fmp = fmp + s0 (the top stack value is added to FMP)
-    enf fmp' = fmp + s0;
-
-    # Stack behavior: Left shift by 1 (removes the value from stack)
-    enf s0' = s1; enf s1' = s2; enf s2' = s3; enf s3' = s4; enf s4' = s5; enf s5' = s6; enf s6' = s7; enf s7' = s8;
-    enf s8' = s9; enf s9' = s10; enf s10' = s11; enf s11' = s12; enf s12' = s13; enf s13' = s14; enf s14' = s15;
-    # s15' comes from overflow table or is 0 (handled by left_shift_zero_insertion)
 }
 
 # SPLIT operation: Flow control operation for conditional execution (high-degree)
@@ -2163,6 +2202,7 @@ ev dyncall_operation_constraints([s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s
     enf s0' = s1; enf s1' = s2; enf s2' = s3; enf s3' = s4; enf s4' = s5; enf s5' = s6; enf s6' = s7; enf s7' = s8;
     enf s8' = s9; enf s9' = s10; enf s10' = s11; enf s11' = s12; enf s12' = s13; enf s13' = s14; enf s14' = s15;
     # s15' from overflow table or 0 (handled by left_shift_zero_insertion)
+    # Note: overflow-table removal for DYNCALL uses decoder hasher state, not b1'.
 
     # Reset stack depth and overflow address for new context
     enf b0' = 16;

--- a/constraints/utils.air
+++ b/constraints/utils.air
@@ -167,12 +167,16 @@ const MEMREADELEMENT = 12;         # Element read operation (1 element)
 const MEMWRITEWORD = 20;           # Word write operation (4 elements)
 const MEMREADWORD = 28;            # Word read operation (4 elements)
 
-# ACE Chiplet Operation Labels
+# ACE Chiplet Operation Label
 const ACEINIT = 8;                 # ACE circuit initialization (uses bus_6_chiplets_bus)
+
+# Log Precompile Operation label
+const LOGPRECOMPILE = 94;
 
 # Kernel ROM Chiplet Operation Labels
 const KERNELPROCCALL = 16;         # Kernel procedure call
 const KERNELPROCINIT = 48;         # Kernel procedure initialization
+
 ##########################################################################################
 # GENERAL CONSTANTS
 ##########################################################################################


### PR DESCRIPTION
## Describe your changes

Updates a number of constraints to take into account some of the changes made lately to the VM. it also fixes a few mismatches with the design docs.

Here is a roadmap for reviewing up to this PR:

  - #526: Fix cross module constants and comprehension scoping (base: next)
  - #527: Miden VM constraints tracking branch which contains work that was already reviewed (base: al-fix-cross-module-constants-and-
    comprehension-scoping)
  - #528: Add decoder and stack constraints (base: vm-constraints-new)
  - #494: Implementation of system constraints (base: al-stack-constraints)
  - #497: Chiplets bus constraints (base: al-system-constraints)
  - #498: Virtual table bus (base: al-chiplets-bus)
  - #530: Add decoder virtual table bus constraints (base: al-virtual-table-bus)
  - #499: Complete range checker (base: al-decoder-virtual-tables-v2)
  - #500: ACE wire bus constraints (base: al-range-checker)
  - #501: Add constraints for frie2f4 op (base: al-wire-bus)
  - #537: Misc. updates and clarifying notes (base: al-frie2f4)

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`
