### PR TITLE
docs: add pure functions guide to AirScript mdBook

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
   - [Type declarations](./description/declarations.md)
   - [Constraint descriptions](./description/constraints.md)
   - [Variables](./description/variables.md)
+  - [Pure Functions](./description/functions.md)
   - [Evaluators](./description/evaluators.md)
   - [Buses](./description/buses.md)
   - [Convenience syntax](./description/convenience.md)

--- a/docs/src/description/functions.md
+++ b/docs/src/description/functions.md
@@ -1,0 +1,113 @@
+# Pure Functions
+
+Pure functions let you package reusable expressions that return values. Unlike
+[evaluators](./evaluators.md), pure functions do not describe constraints directly. Use a pure
+function when you want to reuse a computed value; use an evaluator when you want to reuse one or
+more `enf` statements.
+
+## Defining a function
+
+A pure function is declared with the `fn` keyword, followed by the function name, typed
+parameters, a return type, and a body:
+
+```
+fn fold_sum(a: felt[4]) -> felt {
+    return a[0] + a[1] + a[2] + a[3];
+}
+```
+
+The examples below use `felt` scalars and `felt[n]` fixed-size vectors.
+
+## Local bindings and return values
+
+Function bodies can contain local `let` bindings before the final `return`:
+
+```
+fn fold_vec(a: felt[4]) -> felt {
+    let m = a[0] * a[1];
+    let n = m * a[2];
+    let o = n * a[3];
+    return o;
+}
+```
+
+This is useful when the same expression would otherwise be repeated across multiple constraints.
+
+## Calling functions from constraints
+
+Pure functions can be called anywhere a value expression is valid inside
+`integrity_constraints`: in local bindings, in binary expressions, and on the right-hand side of
+`enf` statements.
+
+```
+trace_columns {
+    main: [t, v, b[4]],
+}
+
+public_inputs {
+    stack_inputs: [16],
+}
+
+boundary_constraints {
+    enf v.first = 0;
+}
+
+fn fold_sum(a: felt[4]) -> felt {
+    return a[0] + a[1] + a[2] + a[3];
+}
+
+fn fold_vec(a: felt[4]) -> felt {
+    let m = a[0] * a[1];
+    let n = m * a[2];
+    let o = n * a[3];
+    return o;
+}
+
+integrity_constraints {
+    let folded = fold_vec(b);
+    enf folded = 1;
+    enf t * fold_vec(b) = 1;
+    enf v' = fold_sum(b) * fold_vec(b);
+}
+```
+
+In the example above, `fold_vec(b)` and `fold_sum(b)` are used both as standalone computed values
+and as part of larger expressions.
+
+## Calling functions from other functions
+
+Pure functions can call other pure functions:
+
+```
+fn fold_sum(a: felt[4]) -> felt {
+    return a[0] + a[1] + a[2] + a[3];
+}
+
+fn fold_vec(a: felt[4]) -> felt {
+    let m = a[0] * a[1];
+    let n = m * a[2];
+    let o = n * a[3];
+    return o;
+}
+
+fn combined(a: felt[4]) -> felt {
+    return fold_sum(a) * fold_vec(a);
+}
+```
+
+## Using functions inside evaluators
+
+Pure functions can also be called from [evaluators](./evaluators.md):
+
+```
+fn fold_sum(a: felt[4]) -> felt {
+    return a[0] + a[1] + a[2] + a[3];
+}
+
+ev transition([a, b[4]]) {
+    enf a' = fold_sum(b);
+}
+```
+
+Use pure functions for reusable value-level logic, and evaluators for reusable constraint-level
+logic.

--- a/docs/src/description/keywords.md
+++ b/docs/src/description/keywords.md
@@ -12,6 +12,7 @@ AirScript defines the following keywords:
 - `enf`: used to describe a single [constraint](./constraints.md).
   - `enf match`: used to describe [conditional constraints](./convenience.md#conditional-constraints).
 - `ev`: used to declare a transition constraint [evaluator](./evaluators.md).
+- `fn`: used to declare a [pure function](./functions.md).
 - `for`: used to specify the bound variable in a [list comprehensions](./convenience.md#list-comprehension).
 - `in`: used to specify the iterable in a [list comprehension](./convenience.md#list-comprehension).
 - `insert`: used to insert a tuple to a [bus](./declarations.md#buses-buses). _It may only be used when defining integrity constraints._
@@ -22,6 +23,7 @@ AirScript defines the following keywords:
 - `prod`: used to fold a list into a single value by multiplying all of the values in the list together.
 - `public_inputs`: used to declare the source section where the [public inputs are declared](./declarations.md). _They may only be referenced when defining boundary constraints._
 - `remove`: used to remove a tuple from a [bus](./declarations.md#buses-buses). _It may only be used when defining integrity constraints._
+- `return`: used to return a value from a [pure function](./functions.md).
 - `sum`: used to fold a list into a single value by summing all of the values in the list.
 - `trace_columns`: used to declare the source section where the [execution trace is described](./declarations.md). _They may only be referenced when defining integrity constraints._
   - `main`: used to declare the main execution trace.

--- a/docs/src/description/main.md
+++ b/docs/src/description/main.md
@@ -5,6 +5,7 @@
 - [Type declarations](./declarations.md)
 - [Constraint descriptions](./constraints.md)
 - [Variables](./variables.md)
+- [Pure Functions](./functions.md)
 - [Evaluators](./evaluators.md)
 - [Buses](./buses.md)
 - [Convenience syntax](./convenience.md)


### PR DESCRIPTION
## Current behavior

The AirScript mdBook currently has little documentation on how to define and use pure functions.

In particular:
- there is no dedicated page explaining `fn` syntax and usage
- the language description navigation does not include pure functions
- the keywords page does not document `fn` or `return`

## New behavior

This change adds a dedicated pure functions page to the mdBook and links it from the existing language description navigation.

It also updates the keywords page to document:
- `fn`
- `return`

## Breaking changes

None.

## Other info

Documentation-only update.
Closes #436.