### PR TITLE
fix: avoid trace-access collisions in CSE random inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Incremented MSRV to 1.89.
 - Add a pass for common subexpression elimination in the constraint graph (#419).
+- Fix `RandomInputs` trace-access indexing collision that could cause common-subexpression elimination to incorrectly merge distinct trace cells when `row_offset >= 2`.
 - Reorder unrolling passes to unroll list comprehensions before match statements (#431).
 - Refactored the unrolling pass in MIR (#434).
 - Update documentation and tests thereof (#437).

--- a/air/src/graph/cse.rs
+++ b/air/src/graph/cse.rs
@@ -83,3 +83,86 @@ impl AlgebraicGraph {
         renumbering_map
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use air_parser::ast::TraceSegmentId;
+
+    use crate::{AlgebraicGraph, Operation, Value, ir::TraceAccess};
+
+    /// Regression test for a bug where `RandomInputs::eval`'s indexing scheme for
+    /// `Value::TraceAccess` computed `index = column * 2 + row_offset`, implicitly assuming
+    /// `row_offset` was always 0 or 1.
+    ///
+    /// That assumption does not hold in general: `row_offset` can be 2 or greater for
+    /// constraints spanning larger frames (see `ConstraintDomain::EveryFrame`), reachable via
+    /// ordinary evaluator/function composition (row offsets accumulate when an evaluator that
+    /// applies `'` to one of its own parameters is invoked with an already-offset argument).
+    /// In that case the flat index collided between unrelated columns, e.g.:
+    ///
+    ///   (column=0, row_offset=2) -> index = 0 * 2 + 2 = 2
+    ///   (column=1, row_offset=0) -> index = 1 * 2 + 0 = 2
+    ///
+    /// Both would be assigned the exact same random evaluation -- not a negligible-probability
+    /// collision, but a deterministic one caused by the indexing scheme itself -- causing
+    /// `eliminate_common_subexpressions` to incorrectly treat two distinct trace cells as
+    /// equal and merge them, silently corrupting every reference to either one.
+    ///
+    /// After the fix (keying random values on `(column, row_offset)` directly instead of a
+    /// derived flat index), these two nodes must remain distinct.
+    #[test]
+    fn distinct_trace_accesses_with_colliding_legacy_index_are_not_merged_by_cse() {
+        let mut graph = AlgebraicGraph::default();
+
+        let col0_offset2 = graph.insert_node(Operation::Value(Value::TraceAccess(
+            TraceAccess::new(TraceSegmentId::Main, 0, 2),
+        )));
+        let col1_offset0 = graph.insert_node(Operation::Value(Value::TraceAccess(
+            TraceAccess::new(TraceSegmentId::Main, 1, 0),
+        )));
+
+        // Sanity check: insert_node must not have deduped these -- they are genuinely distinct
+        // Value nodes (different column AND different offset).
+        assert_ne!(
+            col0_offset2, col1_offset0,
+            "precondition failed: the two trace accesses were already deduped structurally"
+        );
+
+        let renumbering_map = graph.eliminate_common_subexpressions();
+
+        let new_col0_offset2 = renumbering_map[&col0_offset2];
+        let new_col1_offset0 = renumbering_map[&col1_offset0];
+
+        assert_ne!(
+            new_col0_offset2, new_col1_offset0,
+            "main[0]'' (col=0, offset=2) and main[1] (col=1, offset=0) are distinct trace cells \
+             and must not be merged by common-subexpression elimination"
+        );
+    }
+
+    /// Same scenario as above, but also checks a case that already worked correctly before the
+    /// fix (offsets 0 and 1 on different columns), to guard against a regression in the other
+    /// direction (e.g. accidentally treating every trace access as distinct).
+    #[test]
+    fn identical_trace_accesses_are_still_merged_by_cse() {
+        let mut graph = AlgebraicGraph::default();
+
+        let a = graph.insert_node(Operation::Value(Value::TraceAccess(TraceAccess::new(
+            TraceSegmentId::Main,
+            0,
+            1,
+        ))));
+        let b = graph.insert_node(Operation::Value(Value::TraceAccess(TraceAccess::new(
+            TraceSegmentId::Main,
+            0,
+            1,
+        ))));
+
+        // insert_node already dedupes structurally-identical Value nodes, so this should be the
+        // very same node index even before CSE runs.
+        assert_eq!(a, b);
+
+        let renumbering_map = graph.eliminate_common_subexpressions();
+        assert_eq!(renumbering_map[&a], renumbering_map[&b]);
+    }
+}

--- a/air/src/ir/random_inputs.rs
+++ b/air/src/ir/random_inputs.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 use alloc::collections::BTreeMap;
 
-use air_parser::ast::TraceSegmentId;
+use air_parser::ast::{TraceColumnIndex, TraceSegmentId};
 use mir::ir::{QuadFelt, const_quad_felt, query_indexed_eval, query_mapped_eval};
 use rand::{SeedableRng, rngs::StdRng};
 use winter_math::fields::f64::BaseElement as Felt;
@@ -18,10 +18,16 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct RandomInputs {
     rng: StdRng,
-    // A vector to hold the random values taken for the main trace, indexed in the following way:
-    // $main[0], $main[0]', $main[1], $main[1]', $main[2], ...
-    main_trace: Vec<QuadFelt>,
-    aux_trace: Vec<QuadFelt>,
+    // Maps a (column, row_offset) pair to the random value assigned to that trace cell.
+    //
+    // NOTE: this used to be a `Vec<QuadFelt>` indexed by `column * 2 + row_offset`, which
+    // implicitly assumed `row_offset` was always 0 or 1. That assumption does not hold in
+    // general: `row_offset` can be 2 or greater for constraints spanning larger frames (see
+    // `ConstraintDomain::EveryFrame`), and in that case the flat index collided between
+    // unrelated columns (e.g. column 0 at offset 2 and column 1 at offset 0 both mapped to
+    // index 2), causing CSE to incorrectly treat two distinct trace cells as equal.
+    main_trace: BTreeMap<(TraceColumnIndex, usize), QuadFelt>,
+    aux_trace: BTreeMap<(TraceColumnIndex, usize), QuadFelt>,
     rand_values: Vec<QuadFelt>,
     public_inputs: BTreeMap<PublicInputAccess, QuadFelt>,
     periodic_columns: BTreeMap<PeriodicColumnAccess, QuadFelt>,
@@ -37,8 +43,8 @@ impl Default for RandomInputs {
     fn default() -> Self {
         Self {
             rng: StdRng::from_seed(CSE_RNG_SEED),
-            main_trace: Vec::new(),
-            aux_trace: Vec::new(),
+            main_trace: BTreeMap::new(),
+            aux_trace: BTreeMap::new(),
             rand_values: Vec::new(),
             public_inputs: BTreeMap::new(),
             periodic_columns: BTreeMap::new(),
@@ -81,23 +87,23 @@ impl RandomInputs {
                     self.evals_map.insert(*node_index, eval);
                     eval
                 },
-                // For each trace segment, we associate a random value to each trace access,
-                // indexed in the following way, each column having two
-                // distinct evaluations to account for the two possible row offsets:
-                // $main[0], $main[0]', $main[1], $main[1]', $main[2], ...
-                // Note: if we encounter a trace access corresponding to an index we have not
-                // yet evaluated, we will randomly generate values for
-                // this trace access, but also for all previous indices.
+                // For each trace segment, we associate a random value to each distinct
+                // (column, row_offset) pair. Row offsets are not limited to 0/1: constraints
+                // over larger frames (see `ConstraintDomain::EveryFrame`) can reference a
+                // column at an arbitrary offset, so we key directly on (column, row_offset)
+                // rather than deriving a flat index, which previously collided between
+                // unrelated columns whenever row_offset >= 2 (e.g. column 0 at offset 2 and
+                // column 1 at offset 0 both mapped to the same flat index).
                 Value::TraceAccess(trace_access) => match trace_access.segment {
                     TraceSegmentId::Main => {
-                        let index = trace_access.column * 2 + trace_access.row_offset;
-                        let eval = query_indexed_eval(&mut self.rng, &mut self.main_trace, index);
+                        let key = (trace_access.column, trace_access.row_offset);
+                        let eval = query_mapped_eval(&mut self.rng, &mut self.main_trace, &key);
                         self.evals_map.insert(*node_index, eval);
                         eval
                     },
                     TraceSegmentId::Aux => {
-                        let index = trace_access.column * 2 + trace_access.row_offset;
-                        let eval = query_indexed_eval(&mut self.rng, &mut self.aux_trace, index);
+                        let key = (trace_access.column, trace_access.row_offset);
+                        let eval = query_mapped_eval(&mut self.rng, &mut self.aux_trace, &key);
                         self.evals_map.insert(*node_index, eval);
                         eval
                     },


### PR DESCRIPTION
Related to #275

RandomInputs::eval could assign the same random value to different trace cells because it encoded (column, row_offset) as column * 2 + row_offset, which is not unique. This caused CSE to incorrectly merge distinct trace accesses. The fix uses the full (column, row_offset) pair as the key, with a regression test confirming that distinct accesses stay separate while genuinely identical ones are still merged.